### PR TITLE
Fixed a crash in vdc-manage

### DIFF
--- a/dcmgr/lib/dcmgr/cli/backup_object.rb
+++ b/dcmgr/lib/dcmgr/cli/backup_object.rb
@@ -22,9 +22,9 @@ module Dcmgr::Cli
     def add
       bkst = M::BackupStorage[options[:storage_id]] || UnknownUUIDError.raise("Backup Storage UUID: #{options[:storage_id]}")
 
-      options[:allocation_size] ||= options[:size]
-      
       fields = options.dup
+      fields[:allocation_size] ||= options[:size]
+
       fields.delete(:storage_id)
       fields[:backup_storage_id] = bkst.id
       puts super(M::BackupObject, fields)
@@ -61,7 +61,6 @@ module Dcmgr::Cli
       super(M::BackupObject,uuid)
     end
 
-    
     desc "show [UUID]", "Show the backup object details"
     def show(uuid=nil)
       if uuid


### PR DESCRIPTION
I fixed the following crash:

vdc-manage>> backupobject modify bo-lucid6d --storage-id bkst-demo1
ERROR: undefined local variable or method `bkst' for Dcmgr::Cli::BackupObject:0x000000030156f0
