### PR TITLE
fixed backup_object.size_mb it take the last three digits.

### DIFF
--- a/dcmgr/lib/dcmgr/endpoints/12.03/quota_definitions.rb
+++ b/dcmgr/lib/dcmgr/endpoints/12.03/quota_definitions.rb
@@ -95,7 +95,7 @@ Sinatra::QuotaEvaluation.evaluators do
   end
   quota_type 'backup_object.size_mb' do
     fetch do
-      ('%.3f' % ((self.instance_exec(M::BackupObject.alives, &COMMON_DS_FILTER).sum(:size) || 0) / (1024 * 1024))).to_f
+      ((self.instance_exec(M::BackupObject.alives, &COMMON_DS_FILTER).sum(:size) || 0) / (1024 * 1024)).truncate
     end
 
     evaluate do |fetch_value| 


### PR DESCRIPTION
```
((self.instance_exec(M::BackupObject.alives, &COMMON_DS_FILTER).sum(:size) || 0) / (1024 * 1024))
=> #<BigDecimal:3099018,'0.1276263671 875E4',18(54)>
```

```
'%.3f' % ((self.instance_exec(M::BackupObject.alives, &COMMON_DS_FILTER).sum(:size) || 0) / (1024 * 1024))
=> "1276.264"
```

```
('%.3f' % ((self.instance_exec(M::BackupObject.alives, &COMMON_DS_FILTER).sum(:size) || 0) / (1024 * 1024))).to_f
=> 1276.264
```

/api/12.03/accounts/a-shpoolxx/usage

before

```
"backup_object.size_mb":"0.1276263671875E4"
```

after

```
"backup_object.size_mb":1276.264
```
