### PR TITLE
Fix for instance state during power-on operation.

### DIFF
--- a/dcmgr/lib/dcmgr/rpc/hva_handler.rb
+++ b/dcmgr/lib/dcmgr/rpc/hva_handler.rb
@@ -476,7 +476,8 @@ module Dcmgr
         @hva_ctx = HvaContext.new(self)
         @inst_id = request.args[0]
         @inst = rpc.request('hva-collector', 'get_instance', @inst_id)
-
+        update_instance_state({:state=>:starting}, [])
+        
         @hva_ctx.logger.info("Turning power on")
         task_session.invoke(@hva_ctx.hypervisor_driver_class,
                             :poweron_instance, [@hva_ctx])


### PR DESCRIPTION
When an instance is powered on, the state is changed to "running" immediatly. It is wrong behavior from the state diagram.

This change corrects the state transition: "halted" -> "starting" -> "running".
