### PR TITLE
Bug secg api create crash

### DIFF
--- a/dcmgr/lib/dcmgr/models/security_group.rb
+++ b/dcmgr/lib/dcmgr/models/security_group.rb
@@ -96,9 +96,6 @@ module Dcmgr::Models
       }
 
       # Destroy relations with groups that are no longer referenced
-        p self.referencees
-        p action
-        p current_ref_group_ids
       self.referencees_dataset.each { |referencee|
         unless current_ref_group_ids.member?(referencee.canonical_uuid)
           self.remove_referencee(referencee)


### PR DESCRIPTION
The security groups api used to crash when creating a security group that references another group right of the bat. I fixed that.

Also reference entries in the database didn't get removed when removing the security groups themselves. Fixed that too.
