### PR TITLE
Supported JSON CSRF for CORS

### DIFF
--- a/dcmgr/Gemfile
+++ b/dcmgr/Gemfile
@@ -31,3 +31,4 @@ gem 'trema', :git=>'http://github.com/axsh/trema.git', :branch=>'wakame'
 gem 'rack-cors', :require => 'rack/cors'
 
 gem 'multi_json'
+gem 'rack-protection', :git=>'http://github.com/rkh/rack-protection.git', :ref => '4a771b640d70dc1acc54b93e654537a5efec0491'


### PR DESCRIPTION
Latest gem version doesn't support json csrf since I was used the latest Github commit id.
