### PR TITLE
Fixed netfilter crash when deleting 2 load balancers

### DIFF
--- a/dcmgr/lib/dcmgr/node_modules/service_netfilter.rb
+++ b/dcmgr/lib/dcmgr/node_modules/service_netfilter.rb
@@ -190,7 +190,7 @@ module Dcmgr
               @cache.remove_security_group(group_id) unless @cache.other_local_vnics_left_in_group?(vnic_id,group_id)
             }
 
-            @cache.remove_network(vif[:network_id]) unless @cache.local_vnics_left_in_network?(vif[:network_id])
+            @cache.remove_network(vif[:network_id]) unless @cache.local_vnics_left_in_network?(vif[:network_id]) || @cache.empty_vnics_left_in_network?(vif[:network_id])
           }
         end
 

--- a/dcmgr/lib/dcmgr/vnet/netfilter/cache.rb
+++ b/dcmgr/lib/dcmgr/vnet/netfilter/cache.rb
@@ -334,6 +334,10 @@ module Dcmgr
           not vnics.nil?
         end
 
+        def empty_vnics_left_in_network?(network_id)
+          not @cache[:empty_vnics].values.find {|vnic| vnic[:network_id] == network_id }.nil?
+        end
+
         def network_exists?(network_id)
           @cache[:networks].has_key?(network_id)
         end


### PR DESCRIPTION
When removing a network from the cache, there was no check for empty vnics (that are not in a security group) that might still be left in the network. Therefore it was possible for a network to be removed from the cache while there were still vnics in it. If that happened, there would be a crash the next time a vnic in said network was destroyed. I added the necessary check and now it works
