### PR TITLE
Created instance force-delete command

### DIFF
--- a/dcmgr/lib/dcmgr/cli/instance.rb
+++ b/dcmgr/lib/dcmgr/cli/instance.rb
@@ -54,5 +54,10 @@ __END
 
     end
 
+    desc "force-delete UUID", "Delete all of an instance's resources in the database but don't terminate the actual VM. Use only if you know what you're doing!"
+    def force_delete(uuid)
+      del(M::Instance,uuid)
+    end
+
   end
 end


### PR DESCRIPTION
When running the failure recovery script, it would set instance states to terminated without altering anything else. The problem is that other resources like vnic and iplease aren't freed and the terminated instances will remain on the GUI forever. This new command can be used to solve that.
