### PR TITLE
Rpmbuild

### DIFF
--- a/rpmbuild/SPECS/wakame-vdc.spec
+++ b/rpmbuild/SPECS/wakame-vdc.spec
@@ -191,6 +191,10 @@ Group: Development/Languages
 Requires: %{oname}-hva-common-vmapp-config = %{version}-%{release}
 Requires: vzkernel = 2.6.32-042stab055.16
 Requires: vzctl = 3.3-1
+Requires: vzctl-lib = 3.3-1
+Requires: vzquota = 3.1-1
+Requires: ploop = 1.4-1
+Requires: ploop-lib = 1.4-1
 %description  hva-openvz-vmapp-config
 <insert long description, indented with spaces>
 


### PR DESCRIPTION
1. fix package dependency of hva-kvm-vmapp-config with %ifarch
   - in order to install qemu-kvm using hva-kvm-vmapp-config
2. add pkg dependency for openvz with version
   - vzkernel 2.6.32-042stab055.16 should use vzutils 3.3-1
