### PR TITLE
openvz: fix to be able to run CT without vifs.

### DIFF
--- a/dcmgr/templates/openvz/template.mount
+++ b/dcmgr/templates/openvz/template.mount
@@ -13,8 +13,9 @@ mount -n -t simfs METADATA ${DST} -o ${SRC},noexec,nosuid
 NETIFLIST=$(printf %s "$NETIF" |tr ';' '\n')
 
 if [ -z "${NETIFLIST}" ]; then
-    echo "Error: CT$VEID has no veth interface configured" 1>&2
-    exit 1
+    # should be able to run CT without vifs
+    echo "Warning: CT$VEID has no veth interface configured" 1>&2
+    exit 0
 fi
 
 for iface in ${NETIFLIST}; do


### PR DESCRIPTION
precondition
1. hva's hypervisor type should be openvz
2. an instance should have no vifs

failed case.

```
##STDOUT=>
Starting container ...
Initializing quota ...
##STDERR=>
Warning: distribution not specified in CT config, using defaults from /etc/vz/dists/default
Error: CT112 has no veth interface configured
Error executing mount script /etc/vz/conf/112.mount /opt/axsh/wakame-vdc/dcmgr/lib/dcmgr/helpers/cli_helper.rb:180:in `block in run!'
```

CT should be able to run without vifs. this change will fix it.

```
##STDOUT=>
Starting container ...
Initializing quota ...
Container is mounted
Setting CPU units: 1000
Setting CPUs: 1
Container start in progress...
##STDERR=>
Warning: distribution not specified in CT config, using defaults from /etc/vz/dists/default
Warning: CT111 has no veth interface configured
I, [2012-10-25T18:12:20.928537 #10627]  INFO -- HvaHandler: Instance UUID: i-rzfwm6or: Started container
2012-10-25 18:12:21 JobContext thr=LocalStore[0/2] [INFO]: Job complete 95da8f4b690027087a15fc7b62d9571d95555986 (Local ID: 861b7efb0e66fe523ff90bb606aaeb240b6b03a1)[ run_local_store ]: 31.658539748 sec
```
