### PR TITLE
Workaround NoMethodError for warning loglevel

### DIFF
--- a/dcmgr/lib/dcmgr/models/network_vif.rb
+++ b/dcmgr/lib/dcmgr/models/network_vif.rb
@@ -107,7 +107,7 @@ module Dcmgr::Models
       if maclease
         maclease.destroy
       else
-        logger.warning "Warning: Mac address lease for '#{self.mac_addr}' not found in database."
+        logger.info "Warning: Mac address lease for '#{self.mac_addr}' not found in database."
       end
       release_ip_lease
       self.remove_all_security_groups


### PR DESCRIPTION
During the mac address range pull request, I was told to use "logger.warning". When I tried it again recently, it threw a NoMethodError. I think logger.warning should be possible but don't have time to implement it right now. Therefore I want to work around it for now by using logger.info.
