### PR TITLE
Domain capacity check bug

### DIFF
--- a/dcmgr/lib/dcmgr/models/host_node.rb
+++ b/dcmgr/lib/dcmgr/models/host_node.rb
@@ -117,7 +117,7 @@ module Dcmgr::Models
 
     # Check the free resource capacity across entire local VDC domain.
     def self.check_domain_capacity?(cpu_cores, memory_size, num=1)
-      ds = Instance.dataset.lives
+      ds = Instance.dataset.lives.filter(:host_node => HostNode.online_nodes)
       alives_cpu_cores, alives_mem_size = ds.select{[sum(:cpu_cores), sum(:memory_size)]}.naked.first.values.map { |i| i || 0 }
       stopped_cpu_cores, stopped_mem_size = ds.filter(:state=>'stopped').select{ [sum(:cpu_cores), sum(:memory_size)] }.naked.first.values.map { |i| i || 0 }
       # instance releases the resources during stopped state normally. however admins may


### PR DESCRIPTION
# Bug

Some times while you start an instance when some host nodes are offline, you will get an _OutOfHostCapacity_ error even when the online host nodes have enough capacity to host the new instance.
# Cause

When starting a new instance, a domain capacity check is made. This check does the following:
- Take the sum of all **online** host nodes' capacity
- Take the sum of all instances on **online** host nodes AND those on **offline** host nodes
- If the above instance usage is greater than the capacity, the error is raised.

The problem is that it is possible that there are still instances running on offline nodes. These get counted in the capacity check and therefore it can happen that the error is raised even when the online nodes have enough capacity to host new instances.
# Solution
- Only take the sum of all instances on **online** host nodes. Do not include the **offline** ones.
