### PR TITLE
rpmbuild: make stable trema path.

### DIFF
--- a/rpmbuild/SPECS/wakame-vdc.spec
+++ b/rpmbuild/SPECS/wakame-vdc.spec
@@ -336,6 +336,11 @@ rm -rf ${RPM_BUILD_ROOT}
 %post
 /sbin/chkconfig --add vdc-net-event
 
+# fix trema path
+[[ -L /var/lib/%{oname}/trema ]] && rm -f /var/lib/%{oname}/trema
+trema_home_realpath=`cd %{prefix}/%{oname}/dcmgr && %{prefix}/%{oname}/ruby/bin/bundle show trema`
+[[ -z "${trema_home_realpath}" ]] || ln -fs ${trema_home_realpath} /var/lib/%{oname}/trema
+
 %post debug-config
 %{prefix}/%{oname}/rpmbuild/helpers/sysctl.sh < /etc/sysctl.d/30-dump-core.conf
 


### PR DESCRIPTION
## issues
- trema needs TREMA_HOME environment value.
- if you installed trema with gem/bundle, trema installation path depends on ruby version and trema version.
  - ex.) /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/1.9.1/bundler/gems/trema-5df1d87d5ee7
- hva.conf expects stable path, even if updating rpm packages.
## solutions
- making a symlink from real path to the path which hva expects at hva.conf.

this change will make a stable installation path.

```
# ls -la /var/lib/wakame-vdc/trema
lrwxrwxrwx 1 root root 83 Oct 31 22:00 /var/lib/wakame-vdc/trema -> /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/1.9.1/bundler/gems/trema-5df1d87d5ee7
```
