### PR TITLE
Show disk size in GB with more precision control

### DIFF
--- a/frontend/dcmgr_gui/app/views/backups/index.html.erb
+++ b/frontend/dcmgr_gui/app/views/backups/index.html.erb
@@ -56,7 +56,7 @@
             <td class="listcheckbox"></td>
             {{/if}}
 	    <td class="vtip" title="display name">${item.display_name}</td>
-	    <td class="vtip center" title="capacity">${displayByteUnit(this.size)}</td>
+	    <td class="vtip center" title="capacity">${displayDiskSize(this.size)}</td>
 	    <td class="vtip" title="created at">${item.created_at}</td>
 	    <td class="state vtip center" title="status">${item.state}</td>
             {{if item.progress }}

--- a/frontend/dcmgr_gui/app/views/storage_nodes/index.html.erb
+++ b/frontend/dcmgr_gui/app/views/storage_nodes/index.html.erb
@@ -38,7 +38,7 @@ jQuery(function($){
 						<td class="listcheckbox"></td>
 						{{/if}}
 						<td class="vtip" title="uuid">${item.uuid}</td>
-						<td class="vtip center" title="offering_disk_space">${displayByteUnit(this.offering_disk_space_mb, 'MB')}</td>
+						<td class="vtip center" title="offering_disk_space">${displayDiskSize(this.offering_disk_space_mb, 'MB')}</td>
 						<td class="vtip center" title="ipaddr">${item.ipaddr}</td>
 						<td class="vtip center state" title="status" style="width:50px">${item.status}</td>
 					</tr>	
@@ -67,7 +67,7 @@ jQuery(function($){
 					<td>${item.ipaddr}</td>
 					<td class="padcell"></td>
 					<td class="title"><%= t("storage_nodes.details.disk_space") %>:</td>
-					<td>${displayByteUnit(this.offering_disk_space_mb, 'MB')}</td>
+					<td>${displayDiskSize(this.offering_disk_space_mb, 'MB')}</td>
 				</tr>
 				<tr>
 					<td class="padcell"></td>

--- a/frontend/dcmgr_gui/app/views/volumes/index.html.erb
+++ b/frontend/dcmgr_gui/app/views/volumes/index.html.erb
@@ -61,7 +61,7 @@
 	    <td class="listcheckbox"></td>
 	    {{/if}}
 	    <td class="vtip display_name" title="display name">${item.display_name}</td>
-	    <td class="vtip center volume_size" title="size" style="width:40px">${displayByteUnit(this.size, 'MB')}</td>
+	    <td class="vtip center volume_size" title="size" style="width:40px">${displayDiskSize(this.size, 'MB')}</td>
 	    <td class="vtip center" title="backup object id">${item.backup_object_id}</td>
 	    <td class="vtip" title="created">${item.created_at}</td>
 	    <td class="state vtip center" title="status">${item.state}</td>
@@ -102,7 +102,7 @@
           <tr>
 	    <td class="padcell"></td>
 	    <td class="title"><%= t("volumes.details.capacity") %>:</td>
-	    <td>${displayByteUnit(this.size, 'MB')}</td>
+	    <td>${displayDiskSize(this.size, 'MB')}</td>
 	    <td class="padcell"></td>
 	    <td class="title"><%= t("volumes.details.backup_object_id") %>:</td>
 	    <td>${item.backup_object_id}</td>

--- a/frontend/dcmgr_gui/public/javascripts/dcmgr_gui/core.js
+++ b/frontend/dcmgr_gui/public/javascripts/dcmgr_gui/core.js
@@ -77,8 +77,10 @@ DcmgrGUI.Filter = DcmgrGUI.Class.create({
 
 DcmgrGUI.Converter = {};
 
-// Convert number to default display byte unit (GB).
-displayByteUnit = DcmgrGUI.Converter.toDisplayByteUnit = function(qty, unit) {
+// Convert number to display disk size (large byte) unit in GB.
+// <= 10GB is displayed in: 1.01 GB, 0.66GB
+// > 10GB is displayed in: 10 GB, 101GB
+displayDiskSize = DcmgrGUI.Converter.toDisplayDiskSize = function(qty, unit) {
   var q;
   if (qty === undefined || qty == ''){
     return "";
@@ -89,7 +91,11 @@ displayByteUnit = DcmgrGUI.Converter.toDisplayByteUnit = function(qty, unit) {
     if (unit !== undefined ){ qty = qty + unit; }
     q = new Qty(qty);
   }
-  return q.toPrec('0.01 GB').toString('GB');
+  if( q.to('GB').scalar > 10.0 ) {
+    return q.toPrec('GB').toString('GB');
+  }else{
+    return q.toPrec('0.01 GB').toString('GB');
+  }
 };
 
 DcmgrGUI.Converter.unit = function(data, unit_type){


### PR DESCRIPTION
The disk size fields in GUI consume wide range of cell slightly because it always shows fixed point number in GB. The disk size display function have been renamed and improved to change the precision of the disk size number depending on disk size. 
