### PR TITLE
MYSQL_DB_ENGINE variable for choosing engine type at DB migration.

### DIFF
--- a/dcmgr/config/initializers/sequel.rb
+++ b/dcmgr/config/initializers/sequel.rb
@@ -15,7 +15,7 @@ case db.adapter_scheme
 when :mysql, :mysql2
   Sequel::MySQL.default_charset = 'utf8'
   Sequel::MySQL.default_collate = 'utf8_general_ci'
-  Sequel::MySQL.default_engine = 'InnoDB'
+  Sequel::MySQL.default_engine = ENV['MYSQL_DB_ENGINE'] || 'InnoDB'
 
   # this is the mysql adapter specific constants. won't work with mysql2.
   if db.adapter_scheme == :mysql

--- a/frontend/dcmgr_gui/config/initializers/sequel.rb
+++ b/frontend/dcmgr_gui/config/initializers/sequel.rb
@@ -24,7 +24,7 @@ case db.adapter_scheme
 when :mysql, :mysql2
   Sequel::MySQL.default_charset = 'utf8'
   Sequel::MySQL.default_collate = 'utf8_general_ci'
-  Sequel::MySQL.default_engine = 'InnoDB'
+  Sequel::MySQL.default_engine = ENV['MYSQL_DB_ENGINE'] || 'InnoDB'
 end
 # Set timezone to UTC
 Sequel.default_timezone = :utc


### PR DESCRIPTION
default engine type "InnoDB" was hard-coded in initializers/sequel.rb but it causes problem where administrators want to use different MySQL engine type.
