### PR TITLE
vdc-manage: HostNode -> StorageNode

### DIFF
--- a/dcmgr/lib/dcmgr/cli/storage.rb
+++ b/dcmgr/lib/dcmgr/cli/storage.rb
@@ -59,7 +59,7 @@ Create: <%= st.created_at %>
 Update: <%= st.updated_at %>
 __END
     else
-      ds = HostNode.dataset
+      ds = StorageNode.dataset
       table = [['UUID', 'Node ID', 'Storage', 'Status']]
       ds.each { |r|
         table << [r.canonical_uuid, r.node_id, r.storage_type, r.status]


### PR DESCRIPTION
vdc-manage got following error message.

```
# /opt/axsh/wakame-vdc/dcmgr/bin/vdc-manage storage show
ERROR: undefined method `storage_type' for #<Dcmgr::Models::HostNode:0x00000001e8c870> (/opt/axsh/wakame-vdc/dcmgr/lib/dcmgr/cli/storage.rb:65:in `block in show')
```

this change will fix the issue.

```
# /opt/axsh/wakame-vdc/dcmgr/bin/vdc-manage storage show
UUID      Node ID    Storage  Status
sn-demo1  sta.demo1  raw      online
```
