### PR TITLE
Show host node usage in vdc-manage

### DIFF
--- a/dcmgr/lib/dcmgr/cli/host.rb
+++ b/dcmgr/lib/dcmgr/cli/host.rb
@@ -67,8 +67,8 @@ class Host < Base
       puts ERB.new(<<__END, nil, '-').result(binding)
 Host UUID: <%= host.canonical_uuid %>
 Node ID: <%= host.node_id %>
-CPU Cores (offering): <%= host.offering_cpu_cores %>
-Memory (offering): <%= host.offering_memory_size %>MB
+CPU Cores (usage / offering): <%= host.cpu_core_usage %> / <%= host.offering_cpu_cores %>
+Memory (usage / offering): <%= host.memory_size_usage%>MB / <%= host.offering_memory_size %>MB
 Hypervisor: <%= host.hypervisor %>
 Architecture: <%= host.arch %>
 Status: <%= host.status %>
@@ -77,9 +77,9 @@ Update: <%= host.updated_at %>
 __END
     else
       ds = HostNode.dataset
-      table = [['UUID', 'Node ID', 'Hypervisor', 'Architecture', 'Status']]
+      table = [['UUID', 'Node ID', 'Hypervisor', 'Architecture', 'Usage', 'Status']]
       ds.each { |r|
-        table << [r.canonical_uuid, r.node_id, r.hypervisor, r.arch, r.status]
+        table << [r.canonical_uuid, r.node_id, r.hypervisor, r.arch, "#{r.usage_percent}%", r.status]
       }
       shell.print_table(table)
     end

--- a/dcmgr/lib/dcmgr/models/host_node.rb
+++ b/dcmgr/lib/dcmgr/models/host_node.rb
@@ -104,6 +104,14 @@ module Dcmgr::Models
       instances_usage(:memory_size)
     end
 
+    # Returns a usage percentage to show admins in quick overviews
+    def usage_percent
+      cpu_percent = (cpu_core_usage.to_f / offering_cpu_cores.to_f) * 100
+      mem_percent = (memory_size_usage.to_f / offering_memory_size.to_f) * 100
+
+      ((cpu_percent + mem_percent) / 2).to_i
+    end
+
     # Returns available CPU cores.
     def available_cpu_cores
       self.offering_cpu_cores - self.cpu_core_usage


### PR DESCRIPTION
Just a quick commit that adds the ability to show current host node usage through vdc-manage.

```
 ./vdc-manage host show
 UUID      Node ID    Hypervisor  Architecture  Usage  Status
 hn-demo1  hva.demo1  openvz      x86_64        2%     online



 ./vdc-manage host show hn-demo1
 Host UUID: hn-demo1
 Node ID: hva.demo1
 CPU Cores (usage / offering): 4 / 100
 Memory (usage / offering): 1536MB / 400000MB
 Hypervisor: openvz
 Architecture: x86_64
 Status: online
 Create: 2012-11-16 03:38:33 UTC
 Update: 2012-11-16 03:38:33 UTC
```
