### PR TITLE
Change state to initializing

### DIFF
--- a/dcmgr/lib/dcmgr/rpc/hva_handler.rb
+++ b/dcmgr/lib/dcmgr/rpc/hva_handler.rb
@@ -257,7 +257,7 @@ module Dcmgr
 
         @hva_ctx.logger.info("Booting #{@inst_id}: phase 2")
         @inst = rpc.request('hva-collector', 'get_instance',  @inst_id)
-        raise "Invalid instance state: #{@inst[:state]}" unless %w(starting).member?(@inst[:state].to_s)
+        raise "Invalid instance state: #{@inst[:state]}" unless %w(initializing).member?(@inst[:state].to_s)
 
         setup_metadata_drive
 

--- a/dcmgr/lib/dcmgr/rpc/local_store_handler.rb
+++ b/dcmgr/lib/dcmgr/rpc/local_store_handler.rb
@@ -20,7 +20,7 @@ module Dcmgr
         @inst = rpc.request('hva-collector', 'get_instance',  @inst_id)
         raise "Invalid instance state: #{@inst[:state]}" unless %w(pending failingover).member?(@inst[:state].to_s)
 
-        rpc.request('hva-collector', 'update_instance', @inst_id, {:state=>:starting})
+        rpc.request('hva-collector', 'update_instance', @inst_id, {:state=>:initializing})
 
         task_session.invoke(Drivers::LocalStore.driver_class(@inst[:host_node][:hypervisor]),
                             :deploy_image, [@inst, @hva_ctx])


### PR DESCRIPTION
Issue: 

Instance state is the same transition there are the creating state and the power on state.

Fix:
- Change state to initializing when createing instance.

Todo:
- Fx the volume store boot. 
  https://github.com/axsh/wakame-vdc/blob/master/dcmgr/lib/dcmgr/rpc/hva_handler.rb#L295

The reason that volume store boot not working. Threa are a lot of work.
