### PR TITLE
Cli instance show bugfix

### DIFF
--- a/dcmgr/lib/dcmgr/cli/instance.rb
+++ b/dcmgr/lib/dcmgr/cli/instance.rb
@@ -16,7 +16,7 @@ module Dcmgr::Cli
       def show_instances_list(inst_dataset)
         puts ERB.new(<<__END, nil, '-').result(binding)
 <%- inst_dataset.each { |row| -%>
-<%= row.canonical_uuid %>\t<%= row.host_node.canonical_uuid %>\t<%= row.state %>
+<%= row.canonical_uuid %>\t<%= row.host_node.nil? ? "unassigned" : row.host_node.canonical_uuid %>\t<%= row.state %>
 <%- } -%>
 __END
       end


### PR DESCRIPTION
Showing instances through vdc-manage would crash if there were instances that didn't have their hostnode assigned yet. This commit fixes that.
