### PR TITLE
Changed so that unicorn.conf could be set up for every environment.

### DIFF
--- a/contrib/etc/default/vdc-admin
+++ b/contrib/etc/default/vdc-admin
@@ -8,3 +8,4 @@
 RACK_ENV=development
 #BIND_ADDR=0.0.0.0
 #PORT=9003
+#UNICORN_CONF=/etc/wakame-vdc/unicorn-common.conf

--- a/contrib/etc/default/vdc-auth
+++ b/contrib/etc/default/vdc-auth
@@ -8,3 +8,4 @@
 RACK_ENV=development
 #BIND_ADDR=127.0.0.1
 #PORT=3000
+#UNICORN_CONF=/etc/wakame-vdc/unicorn-common.conf

--- a/contrib/etc/default/vdc-dcmgr
+++ b/contrib/etc/default/vdc-dcmgr
@@ -8,3 +8,4 @@
 RACK_ENV=development
 #BIND_ADDR=0.0.0.0
 #PORT=9001
+#UNICORN_CONF=/etc/wakame-vdc/unicorn-common.conf

--- a/contrib/etc/default/vdc-metadata
+++ b/contrib/etc/default/vdc-metadata
@@ -8,3 +8,4 @@
 RACK_ENV=development
 #BIND_ADDR=0.0.0.0
 #PORT=9002
+#UNICORN_CONF=/etc/wakame-vdc/unicorn-common.conf

--- a/contrib/etc/default/vdc-webui
+++ b/contrib/etc/default/vdc-webui
@@ -8,3 +8,4 @@
 RACK_ENV=development
 #BIND_ADDR=0.0.0.0
 #PORT=9000
+#UNICORN_CONF=/etc/wakame-vdc/unicorn-common.conf

--- a/contrib/etc/init/vdc-admin.conf
+++ b/contrib/etc/init/vdc-admin.conf
@@ -28,7 +28,7 @@ script
     exec bundle exec unicorn \
      -o ${BIND_ADDR:-0.0.0.0} \
      -p ${PORT:-9003} \
-     -c /etc/wakame-vdc/unicorn-common.conf ./config.ru 2>&1 \
+     -c ${UNICORN_CONF:-/etc/wakame-vdc/unicorn-common.conf} ./config.ru 2>&1 \
       | /usr/bin/flog \
      -p /var/run/flog-vdc-${NAME}.pid \
         /var/log/wakame-vdc/${NAME}.log

--- a/contrib/etc/init/vdc-auth.conf
+++ b/contrib/etc/init/vdc-auth.conf
@@ -28,7 +28,7 @@ script
     exec bundle exec unicorn \
      -o ${BIND_ADDR:-127.0.0.1} \
      -p ${PORT:-3000} \
-     -c /etc/wakame-vdc/unicorn-common.conf ./config.ru 2>&1 \
+     -c ${UNICORN_CONF:-/etc/wakame-vdc/unicorn-common.conf} ./config.ru 2>&1 \
       | /usr/bin/flog \
      -p /var/run/flog-vdc-${NAME}.pid \
         /var/log/wakame-vdc/${NAME}.log

--- a/contrib/etc/init/vdc-dcmgr.conf
+++ b/contrib/etc/init/vdc-dcmgr.conf
@@ -28,7 +28,7 @@ script
     exec bundle exec unicorn \
      -o ${BIND_ADDR:-0.0.0.0} \
      -p ${PORT:-9001} \
-     -c /etc/wakame-vdc/unicorn-common.conf ./config-${NAME}.ru 2>&1 \
+     -c ${UNICORN_CONF:-/etc/wakame-vdc/unicorn-common.conf} ./config-${NAME}.ru 2>&1 \
       | /usr/bin/flog \
      -p /var/run/flog-vdc-${NAME}.pid \
         /var/log/wakame-vdc/${NAME}.log

--- a/contrib/etc/init/vdc-metadata.conf
+++ b/contrib/etc/init/vdc-metadata.conf
@@ -28,7 +28,7 @@ script
     exec bundle exec unicorn \
      -o ${BIND_ADDR:-0.0.0.0} \
      -p ${PORT:-9002} \
-     -c /etc/wakame-vdc/unicorn-common.conf ./config-${NAME}.ru 2>&1 \
+     -c ${UNICORN_CONF:-/etc/wakame-vdc/unicorn-common.conf} ./config-${NAME}.ru 2>&1 \
       | /usr/bin/flog \
      -p /var/run/flog-vdc-${NAME}.pid \
         /var/log/wakame-vdc/${NAME}.log

--- a/contrib/etc/init/vdc-webui.conf
+++ b/contrib/etc/init/vdc-webui.conf
@@ -28,7 +28,7 @@ script
     exec bundle exec unicorn \
      -o ${BIND_ADDR:-0.0.0.0} \
      -p ${PORT:-9000} \
-     -c /etc/wakame-vdc/unicorn-common.conf ./config.ru 2>&1 \
+     -c ${UNICORN_CONF:-/etc/wakame-vdc/unicorn-common.conf} ./config.ru 2>&1 \
       | /usr/bin/flog \
      -p /var/run/flog-vdc-${NAME}.pid \
         /var/log/wakame-vdc/${NAME}.log


### PR DESCRIPTION
## summary

The preset values of unicorn.conf differ for every environment.
I would like to use another unicorn.conf for every environment.
## implementation
### before the change
- /etc/init/vdc-dcmgr.conf
- /etc/init/vdc-auth.conf
- /etc/init/vdc-admin.conf
- /etc/init/vdc-webui.conf
- /etc/init/vdc-metadata.conf

exec bundle exec unicorn \
     -o ${BIND_ADDR:-0.0.0.0} \
     -p ${PORT:-9001} \
     -c /etc/wakame-vdc/unicorn-common.conf ./config-${NAME}.ru 2>&1 \
      | /usr/bin/flog \
     -p /var/run/flog-vdc-${NAME}.pid \
        /var/log/wakame-vdc/${NAME}.log
### after the change
- /etc/init/vdc-dcmgr.conf
- /etc/init/vdc-auth.conf
- /etc/init/vdc-admin.conf
- /etc/init/vdc-webui.conf
- /etc/init/vdc-metadata.conf

exec bundle exec unicorn \
     -o ${BIND_ADDR:-0.0.0.0} \
     -p ${PORT:-9001} \
     -c ${UNICORN_CONF:-/etc/wakame-vdc/unicorn-common.conf} ./config-${NAME}.ru 2>&1 \
      | /usr/bin/flog \
     -p /var/run/flog-vdc-${NAME}.pid \
        /var/log/wakame-vdc/${NAME}.log
- /etc/default/vdc-dcmgr
- /etc/default/vdc-auth
- /etc/default/vdc-admin
- /etc/default/vdc-webui
- /etc/default/vdc-metadata
# UNICORN_CONF=/etc/wakame-vdc/unicorn-dcmgr.conf
