### PR TITLE
Fix a variable name

### DIFF
--- a/dcmgr/lib/dcmgr/rpc/hva_handler.rb
+++ b/dcmgr/lib/dcmgr/rpc/hva_handler.rb
@@ -219,10 +219,10 @@ module Dcmgr
             "network/interfaces/macs/#{mac}/x-metric" => vnic[:ipv4][:network][:metric],
           })
         }
-        if @inst[:ssh_key_pair]
+        if @inst[:ssh_key_data]
           metadata_items.merge!({
-            "public-keys/0=#{@inst[:ssh_key_pair][:uuid]}" => @inst[:ssh_key_pair][:public_key],
-            'public-keys/0/openssh-key'=> @inst[:ssh_key_pair][:public_key],
+            "public-keys/0=#{@inst[:ssh_key_data][:uuid]}" => @inst[:ssh_key_data][:public_key],
+            'public-keys/0/openssh-key'=> @inst[:ssh_key_data][:public_key],
           })
         else
           metadata_items.merge!({'public-keys/'=>nil})


### PR DESCRIPTION
## Issue: Can't get public key from metadata.
### Fix a bug

Change variable name ssh_key_pair to ssh_key-data.
