### PR TITLE
Load balancer network group regression

### DIFF
--- a/dcmgr/lib/dcmgr/endpoints/12.03/instances.rb
+++ b/dcmgr/lib/dcmgr/endpoints/12.03/instances.rb
@@ -201,12 +201,14 @@ Dcmgr::Endpoints::V1203::CoreAPI.namespace '/instances' do
         raise E::MacNotInRange, mac_addr unless M::MacRange.exists_in_any_range?(m_vid,m_a)
       end
 
-      if temp["network"]
-        check_network_ip_combo(temp["network"],temp["ipv4_addr"])
-      end
+      if params["custom_vifs"]
+        if temp["network"]
+          check_network_ip_combo(temp["network"],temp["ipv4_addr"])
+        end
 
-      if temp["nat_network"]
-        check_network_ip_combo(temp["nat_network"],temp["nat_ipv4_addr"])
+        if temp["nat_network"]
+          check_network_ip_combo(temp["nat_network"],temp["nat_ipv4_addr"])
+        end
       end
     }
 

--- a/dcmgr/lib/dcmgr/scheduler/network/network_group.rb
+++ b/dcmgr/lib/dcmgr/scheduler/network/network_group.rb
@@ -30,7 +30,7 @@ module Dcmgr
           # Create the vnics
           vif_templates = instance.request_params["vifs"] || { "eth0" => {"index"=>"0"} }
           vif_templates.each { |vif_name,vif_temp|
-            tag_id = vif_temp[:network] || options.network_group_id
+            tag_id = vif_temp["network"] || options.network_group_id
             raise Dcmgr::Scheduler::NetworkSchedulingError, "No default network group set" if tag_id.nil?
 
             network_group = Dcmgr::Tags::NetworkGroup[tag_id]


### PR DESCRIPTION
The fixed ip address assignment caused a regression in the network group scheduler. This fixes it.
