### PR TITLE
Fix instance parameter: custom_vifs & custom_host plus monitoring.mail_address

### DIFF
--- a/dcmgr/lib/dcmgr/endpoints/12.03/instances.rb
+++ b/dcmgr/lib/dcmgr/endpoints/12.03/instances.rb
@@ -277,6 +277,8 @@ Dcmgr::Endpoints::V1203::CoreAPI.namespace '/instances' do
         params['monitoring']['mail_address'].each { |k, v|
           instance.instance_monitor_attr.recipients << {:mail_address=>v}
         }
+      when nil
+        # do nothing
       else
         raise "Invalid mail address"
       end


### PR DESCRIPTION
## POST /instances API was getting API design issue and a bug.

custom_vifs and custom_host flag parameters are not good design to set custom IP address or host node manually. I have removed them and changed the pair of required parameters for giving manual IP address and host node. Those parameters were introduced from #106.

Fixed a 500 error bug when monitoring.mail_address parameter is unset.
