### PR TITLE
Disabled haproxy logging

### DIFF
--- a/dcmgr/templates/haproxy/haproxy_http.cfg
+++ b/dcmgr/templates/haproxy/haproxy_http.cfg
@@ -5,8 +5,8 @@ global
     user        haproxy
     group       haproxy
     daemon
-    log         127.0.0.1 local0 debug
-    stats socket /var/lib/haproxy/stats
+    #log         127.0.0.1 local0 debug
+    #stats socket /var/lib/haproxy/stats
 
 defaults
     mode                    http
@@ -21,12 +21,12 @@ defaults
     timeout server          1m
     timeout http-keep-alive 10s
     timeout check           100m
-    stats enable
-    stats hide-version
-    stats scope .
-    stats realm Haproxy\ Statistics
-    stats uri /haproxy?stats
-    stats auth wakame:wakame
+    #stats enable
+    #stats hide-version
+    #stats scope .
+    #stats realm Haproxy\ Statistics
+    #stats uri /haproxy?stats
+    #stats auth wakame:wakame
 
 listen <%= @listen[:name] %> <%= @listen[:bind] %>
     balance    <%= @listen[:balance_algorithm] %>


### PR DESCRIPTION
Load balancers have a bare minimum amount of disk space. This change disables haproxy logging to prevent it from eating up said disk space.
