### PR TITLE
Fixed gui showing wrong load balancer ip

### DIFF
--- a/dcmgr/lib/dcmgr/endpoints/12.03/responses/load_balancer.rb
+++ b/dcmgr/lib/dcmgr/endpoints/12.03/responses/load_balancer.rb
@@ -20,6 +20,7 @@ module Dcmgr::Endpoints::V1203::Responses
           network = vif.network
           ent = {
             :vif_id => vif.canonical_uuid,
+            :vif_index => vif.device_index,
             :network_id => network.nil? ? nil : network.canonical_uuid,
           }
 

--- a/frontend/dcmgr_gui/app/views/load_balancers/index.html.erb
+++ b/frontend/dcmgr_gui/app/views/load_balancers/index.html.erb
@@ -65,7 +65,7 @@
 	    <td class="vtip display_name" title="display name">${item.display_name}</td>
 	    <td class="vtip ip" title="ip">
 	      {{each(index,item) vif}}
-	      {{if vif.ipv4 && index == 0}}
+	      {{if vif.ipv4 && vif.vif_index == 0}}
 	      ${vif.ipv4.ipv4.address}
 	      {{/if}}
 	      {{/each}}</td>
@@ -119,7 +119,7 @@
 	  <tr>
 	    <td class="padcell"></td>
 	    <td class="title"><%= t("load_balancers.details.ip") %></td>
-	    <td colspan="7">{{if item.vif[0].ipv4}}${item.vif[0].ipv4.address}{{/if}}</td>
+      <td colspan="7">{{each(index,vif) item.vif}}{{if vif.ipv4 && vif.vif_index == 0}}${vif.ipv4.address}{{/if}}{{/each}}</td>
 	  </tr>
 	  <tr>
 	    <td class="padcell"></td>


### PR DESCRIPTION
Up until now the load balancer ip in the GUI was hard coded to show the ip of the first vnic in its response array. This was not always the public ip.

I fixed it to show the ip based on vnic device index. The vnic device index is hard coded to 0 in the load balancer API so I matched that in the GUI.
