### PR TITLE
Moves tag map code to model class

### DIFF
--- a/dcmgr/lib/dcmgr/cli/resource_group.rb
+++ b/dcmgr/lib/dcmgr/cli/resource_group.rb
@@ -100,11 +100,7 @@ __DESC
       UnknownUUIDError.raise(object_uuid) if object.nil?
       Error.raise("A '#{object.class}' can not be put into #{uuid}.",100) unless tag.accept_mapping?(object)
 
-      M::TagMapping.create(
-        :tag_id => tag.id,
-        :uuid   => object.canonical_uuid,
-        :sort_index => options[:sort_index]
-      )
+      tag.map_resource(object,options[:sort_index])
     end
 
     desc "index UUID OBJECT_UUID INDEX", "Set the sort index for a resource in a group"

--- a/dcmgr/lib/dcmgr/models/tag.rb
+++ b/dcmgr/lib/dcmgr/models/tag.rb
@@ -54,6 +54,16 @@ module Dcmgr::Models
       ds
     end
 
+    def map_resource(resource, sort_index = 0)
+      raise "This tag can not map resources of type #{resource.class}" unless self.accept_mapping?(resource)
+
+      TagMapping.create(
+        :tag_id => self.id,
+        :uuid   => resource.canonical_uuid,
+        :sort_index => sort_index
+      )
+    end
+
     def self.mappable(resource=nil)
       resource && @mappable = resource
 


### PR DESCRIPTION
Small commit that took the tag mapping code from vdc-manage and move it to the model class so it can be called from other places.
