### PR TITLE
load balancer private network route

### DIFF
--- a/tests/image_builder/build-lb.sh
+++ b/tests/image_builder/build-lb.sh
@@ -177,6 +177,10 @@ function load_balancer_setup() {
 
   cat <<EOF > $tmp_root/etc/rc.local
 /etc/wakame-init md
+
+. /metadata/user-data
+route add -net \${AMQP_SERVER} netmask 255.255.255.255 dev eth1
+
 initctl start haproxy_updater
 exit 0
 EOF


### PR DESCRIPTION
The load balancer doesn't work when the amqp server is in another network segment from the lb's private network interface. This is because the load balancer doesn't realize that it needs to be routed through its private interface.

This is a quick fix that hard codes the route for the amqp server ip address to eth1 which is always the private network interface.
