### PR TITLE
wakame-init: fix metadata-drive-mount-point overwriting path.

### DIFF
--- a/tests/image_builder/rhel/6/wakame-init
+++ b/tests/image_builder/rhel/6/wakame-init
@@ -69,7 +69,11 @@ drive)
     # OpenVZ mounts metadata drive from the outside script.
     METADATA_DRIVE_MOUNTPOINT="/metadata"
   else
-    METADATA_DRIVE_MOUNTPOINT=`mount -l | grep -w METADATA | cut -d " " -f3`
+    mount_output=`mount -l | grep -w METADATA | cut -d " " -f3`
+    [[ -z "${mount_output}" ]] || {
+      # already mounted
+      METADATA_DRIVE_MOUNTPOINT="${mount_output}"
+    }
   fi
 
   if mountpoint -q "${METADATA_DRIVE_MOUNTPOINT}"; then

--- a/tests/image_builder/ubuntu/10.04/wakame-init
+++ b/tests/image_builder/ubuntu/10.04/wakame-init
@@ -97,7 +97,11 @@ drive)
     # OpenVZ mounts metadata drive from the outside script.
     METADATA_DRIVE_MOUNTPOINT="/metadata"
   else
-    METADATA_DRIVE_MOUNTPOINT=`mount -l | grep -w METADATA | cut -d " " -f3`
+    mount_output=`mount -l | grep -w METADATA | cut -d " " -f3`
+    [[ -z "${mount_output}" ]] || {
+      # already mounted
+      METADATA_DRIVE_MOUNTPOINT="${mount_output}"
+    }
 
 
     if mountpoint -q "${MEATADATA_DRIVE_MOUNTPOINT}"; then


### PR DESCRIPTION
wakame-init failed mounting metadata-drive.
- hyperviosr: kvm
- metadata-type: drive

/var/log/wakame-init.log:

`no such labeled device: METADATA`

this change will fix mounting metadata-drive.
