### PR TITLE
small vdc-manage backupobject bugfix

### DIFF
--- a/dcmgr/lib/dcmgr/cli/backup_object.rb
+++ b/dcmgr/lib/dcmgr/cli/backup_object.rb
@@ -49,9 +49,11 @@ module Dcmgr::Cli
       fields = options.dup
       fields.delete(:storage_id)
 
-      bkst = M::BackupStorage[options[:storage_id]]
-      Error.raise("Backup storage '#{options[:storage_id]}' does not exist.",100) if bkst.nil?
-      fields[:backup_storage_id] = bkst.id
+      if options[options[:storage_id]]
+        bkst = M::BackupStorage[options[:storage_id]]
+        Error.raise("Backup storage '#{options[:storage_id]}' does not exist.",100) if bkst.nil?
+        fields[:backup_storage_id] = bkst.id
+      end
 
       super(M::BackupObject, bo.canonical_uuid, fields)
     end


### PR DESCRIPTION
Fixed a bug where a backup object couldn't be modified through vdc-manage unless a backup storage id was provided
