### PR TITLE
hva,lxc: add ipv4 configuration to lxc.conf template.

### DIFF
--- a/dcmgr/templates/lxc/lxc.conf
+++ b/dcmgr/templates/lxc/lxc.conf
@@ -4,6 +4,7 @@ lxc.utsname = <%= ctx.inst_id %>
 lxc.network.type = veth
 <%- if vif[:ipv4] -%>
 lxc.network.link = <%= bridge_if_name(vif[:ipv4][:network][:dc_network]) %>
+lxc.network.ipv4 = <%= vif[:address] %>/<%= vif[:ipv4][:network][:prefix] %>
 <%- end -%>
 lxc.network.veth.pair = <%= vif[:uuid] %>
 lxc.network.hwaddr = <%= vif[:mac_addr].unpack('A2'*6).join(':') %>


### PR DESCRIPTION
in order to configure container ip address.
