### PR TITLE
 hva,lxc: define lxc vif name.

### DIFF
--- a/dcmgr/templates/lxc/lxc.conf
+++ b/dcmgr/templates/lxc/lxc.conf
@@ -6,7 +6,11 @@ lxc.network.type = veth
 lxc.network.link = <%= bridge_if_name(vif[:ipv4][:network][:dc_network]) %>
 lxc.network.ipv4 = <%= vif[:address] %>/<%= vif[:ipv4][:network][:prefix] %>
 <%- end -%>
+
+# *** work-around ***
+# until virtual sysfs implementation
 lxc.network.name = <%= vif[:uuid] %>
+
 lxc.network.veth.pair = <%= vif[:uuid] %>
 lxc.network.hwaddr = <%= vif[:mac_addr].unpack('A2'*6).join(':') %>
 lxc.network.flags = up


### PR DESCRIPTION
change container vif name: ethX -> vif-X

```
[root@qy6w4und ~]# ifconfig
lo        Link encap:Local Loopback
          inet addr:127.0.0.1  Mask:255.0.0.0
          inet6 addr: ::1/128 Scope:Host
          UP LOOPBACK RUNNING  MTU:16436  Metric:1
          RX packets:0 errors:0 dropped:0 overruns:0 frame:0
          TX packets:0 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:0
          RX bytes:0 (0.0 b)  TX bytes:0 (0.0 b)

vif-i64vryid Link encap:Ethernet  HWaddr 52:54:00:49:34:35
          inet addr:10.0.2.101  Bcast:10.0.2.255  Mask:255.255.255.0
          inet6 addr: fe80::5054:ff:fe49:3435/64 Scope:Link
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:31 errors:0 dropped:0 overruns:0 frame:0
          TX packets:48 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000
          RX bytes:2424 (2.3 KiB)  TX bytes:3608 (3.5 KiB)

vif-0msnsdnu Link encap:Ethernet  HWaddr 52:54:00:50:1E:DD
          inet addr:10.0.2.100  Bcast:10.0.2.255  Mask:255.255.255.0
          inet6 addr: fe80::5054:ff:fe50:1edd/64 Scope:Link
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:31 errors:0 dropped:0 overruns:0 frame:0
          TX packets:41 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000
          RX bytes:2452 (2.3 KiB)  TX bytes:3132 (3.0 KiB)
```
