### PR TITLE
mussel: support multi value.

### DIFF
--- a/client/mussel/functions
+++ b/client/mussel/functions
@@ -117,7 +117,7 @@ function add_param() {
 
    case "${param_type}" in
     string) echo   "${param_key}=\${${param_key}}" ;;
-     array) echo "${param_key}[]=\${${param_key}}" ;;
+     array) local i; for i in \${${param_key}}; do echo "${param_key}[]=\${i}"; done ;;
    strfile) strfile_type ${param_key}            ;;
    esac
   "

--- a/client/mussel/test/unit/functions/t.add_param.sh
+++ b/client/mussel/test/unit/functions/t.add_param.sh
@@ -40,6 +40,11 @@ function test_add_param_key_array() {
   assertEquals "$(add_param name array)" "name[]=${name}"
 }
 
+function test_add_param_key_array_multi() {
+  local name="i-xxx i-yyy"
+  assertNotEquals "$(add_param name array)" "$(for i in; do echo name[]=${i}; done)"
+}
+
 function test_add_param_key_strfile() {
   local name=i-xxx
   assertEquals "$(add_param name strfile)" "name=${name}"


### PR DESCRIPTION
code

```
vifs="vif-xxx vif-yyy"
add_param vifs array
```

output

```
vifs[]=vif-xxx 
vifs[]=vif-yyy
```
