### PR TITLE
Bugfix LB unregister instance

### DIFF
--- a/dcmgr/lib/dcmgr/models/load_balancer.rb
+++ b/dcmgr/lib/dcmgr/models/load_balancer.rb
@@ -116,7 +116,7 @@ module Dcmgr::Models
     end
 
     def remove_targets(network_vif_uuids)
-      targets = LoadBalancerTarget.filter(:network_vif_id => network_vif_uuids, :is_deleted => 0).all
+      targets = LoadBalancerTarget.filter(:network_vif_id => network_vif_uuids, :is_deleted => 0, :load_balancer => self).all
       targets.each {|lbt|
         lbt.destroy
       }


### PR DESCRIPTION
# Bug

We have two load balancers. LB1 and LB2. We also have instance A that is registered to both LB1 and LB2. When we unregister A from LB1, it is also removed from LB2.
# Cause

There was no filter for load_balancer_id in the remove_targets method.
# Fix

Added said filter
