### PR TITLE
mussel: add the new namespace "backup_storage".

### DIFF
--- a/client/mussel/test/component/v12.03/t.backup_storage.sh
+++ b/client/mussel/test/component/v12.03/t.backup_storage.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# requires:
+#   bash
+#
+
+## include files
+
+. ${BASH_SOURCE[0]%/*}/helper_shunit2.sh
+
+## variables
+
+declare namespace=backup_storage
+
+## functions
+
+## shunit2
+
+. ${shunit2_file}

--- a/client/mussel/test/integration/v12.03/ro/t.backup_storage.sh
+++ b/client/mussel/test/integration/v12.03/ro/t.backup_storage.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# requires:
+#   bash
+#
+
+## include files
+
+. ${BASH_SOURCE[0]%/*}/helper_shunit2.sh
+
+## variables
+
+declare namespace=$(namespace ${BASH_SOURCE[0]})
+
+## functions
+
+###
+
+function test_index() {
+  step_base_index
+}
+
+function test_show_uuids() {
+  step_base_show_uuids
+}
+
+function test_show_invalid_uuid_syntax() {
+  step_base_show_invalid_uuid_syntax
+}
+
+## shunit2
+
+. ${shunit2_file}

--- a/client/mussel/test/unit/v12.03/t.backup_storage.sh
+++ b/client/mussel/test/unit/v12.03/t.backup_storage.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# requires:
+#   bash
+#
+
+## include files
+
+. ${BASH_SOURCE[0]%/*}/helper_shunit2.sh
+
+## variables
+
+declare namespace=backup_storage
+
+## functions
+
+### help
+
+function test_backup_storage_help_stderr_to_stdout_success() {
+  extract_args ${namespace} help
+  res=$(run_cmd  ${MUSSEL_ARGS} 2>&1)
+  assertEquals "${res}" "$0 ${namespace} [help|destroy|index|show|xcreate]"
+}
+
+## shunit2
+
+. ${shunit2_file}

--- a/client/mussel/v12.03.d/backup_storage.sh
+++ b/client/mussel/v12.03.d/backup_storage.sh
@@ -1,0 +1,6 @@
+# -*-Shell-script-*-
+#
+# 12.03
+#
+
+. ${BASH_SOURCE[0]%/*}/base.sh


### PR DESCRIPTION
# `backup_storage` namespace
## Usage

```
$ mussel.sh backup_storage index
$ mussel.sh backup_storage show [uuid]
```
## Tests
### Unit tests

```
$ cd wakame-vdc/client/mussel

$ ./test/unit/v12.03/t.backup_storage.sh
$ ./test/component/v12.03/t.backup_storage.sh
```
### Integration test: connecting to dcmgr-api endpoint.
- should be running dcmgr-api before running the integration test.

```
$ cd wakame-vdc/client/mussel

$ ./test/integration/v12.03/ro/t.backup_storage.sh
```
