### PR TITLE
hva: fix host_addr detection.

### DIFF
--- a/dcmgr/lib/dcmgr/vnet/network_modes/security_group.rb
+++ b/dcmgr/lib/dcmgr/vnet/network_modes/security_group.rb
@@ -9,7 +9,15 @@ module Dcmgr::VNet::NetworkModes
     def netfilter_all_tasks(vnic,network,friends,security_groups,node)
       tasks = []
 
-      host_addr = Isono::Util.default_gw_ipaddr
+      # ***work-around***
+      # TODO
+      # - multi host nic
+      host_addr = begin
+                    Isono::Util.default_gw_ipaddr
+                  rescue => e
+                    '127.0.0.1'
+                  end
+
       enable_logging = Dcmgr.conf.packet_drop_log
       ipset_enabled = Dcmgr.conf.use_ipset
 


### PR DESCRIPTION
one of Isono::Util.default_gw_ip dependency issue #199 

if host node has no default route, Isono::Util.default_gw_ip cause issue.

```
undefined method `split' for nil:NilClass
        /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/1.9.1/gems/isono-0.2.18/lib/isono/util.rb:44:in `default_gw_ipaddr'
```
