### PR TITLE
Bug vdc manage backup object

### DIFF
--- a/dcmgr/lib/dcmgr/cli/backup_object.rb
+++ b/dcmgr/lib/dcmgr/cli/backup_object.rb
@@ -49,7 +49,7 @@ module Dcmgr::Cli
       fields = options.dup
       fields.delete(:storage_id)
 
-      if options[options[:storage_id]]
+      if options[:storage_id]
         bkst = M::BackupStorage[options[:storage_id]]
         Error.raise("Backup storage '#{options[:storage_id]}' does not exist.",100) if bkst.nil?
         fields[:backup_storage_id] = bkst.id


### PR DESCRIPTION
# Bug 1

It wasn't possible to change backup storage for a backup object through vdc-manage.
# Bug 2

vdc-manage didn't raise a proper error when vdc-manage backupobject show was called with a nonexistant uuid.
# Solutions

Fixed an typo that broke backup storage setting and added proper error handling.
