### PR TITLE
mussel/test: fix retry-sec param.

### DIFF
--- a/client/mussel/test/integration/v12.03/rw/t.instance.vifs.networking.running-out-of-ip.sh
+++ b/client/mussel/test/integration/v12.03/rw/t.instance.vifs.networking.running-out-of-ip.sh
@@ -14,7 +14,7 @@
 network_id="nw-minimum"
 test_case_instance_uuid=
 
-RETRY_WAIT_SEC=1
+RETRY_WAIT_SEC=5
 RETRY_SLEEP_SEC=1
 
 ## functions


### PR DESCRIPTION
it is too fast to wait for instance state on high load system.
