### PR TITLE
Use on_after_commit in load balancer api

### DIFF
--- a/dcmgr/lib/dcmgr/endpoints/12.03/load_balancers.rb
+++ b/dcmgr/lib/dcmgr/endpoints/12.03/load_balancers.rb
@@ -261,11 +261,11 @@ Dcmgr::Endpoints::V1203::CoreAPI.namespace '/load_balancers' do
       # The instance security group has no rules. It's just there to allow
       # communication between the LB and its instances
       lb_inst_secg_id = create_security_group([])
+      M::SecurityGroup[lb_inst_secg_id].set_label(lb.label, uuid)
 
       on_after_commit do
         set_vif_sg(:add, uuid, lb_inst_secg_id)
         set_vif_sg(:add, lb.global_vif.canonical_uuid, lb_inst_secg_id)
-        M::SecurityGroup[lb_inst_secg_id].set_label(lb.label, uuid)
       end
     end
 


### PR DESCRIPTION
Otherwise it's possible for security group related code to be executed before the groups are in the database.
