### PR TITLE
NetworkMonitoring missed abstract method.

### DIFF
--- a/dcmgr/lib/dcmgr/drivers/network_monitoring.rb
+++ b/dcmgr/lib/dcmgr/drivers/network_monitoring.rb
@@ -3,9 +3,15 @@
 module Dcmgr::Drivers
   class NetworkMonitoring
     def register_instance(instance)
+      raise NotImplementedError
     end
 
     def unregister_instance(instance)
+      raise NotImplementedError
+    end
+
+    def update_instance(instance)
+      raise NotImplementedError
     end
 
     def self.driver_class(key)

--- a/dcmgr/lib/dcmgr/drivers/zabbix.rb
+++ b/dcmgr/lib/dcmgr/drivers/zabbix.rb
@@ -188,9 +188,10 @@ module Dcmgr::Drivers
     def register_instance(instance)
     end
 
-
     def unregister_instance(instance)
     end
 
+    def update_instance(instance)
+    end
   end
 end


### PR DESCRIPTION
Report came out when nwmongw ran with zabbix base driver.

```
I, [2013-08-10T20:22:45.794310 #33512]  INFO -- MonitoringGateway: Refreshing monitoring configuration for i-1ieyj8b6
2013-08-10 20:22:45 ThreadPool thr=#<Thread:0x007f6fd06a6bb0> [ERROR]: Caught NoMethodError: undefined method `update_instance' for #<Dcmgr::Drivers::Zabbix:0x007f6fd06a6980>
        ./bin/nwmongw:51:in `refresh_monitoring'
        ./bin/nwmongw:35:in `block (3 levels) in <class:MonitoringGateway>'
        /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/isono-0.2.19/lib/isono/thread_pool.rb:32:in `call'
        /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/isono-0.2.19/lib/isono/thread_pool.rb:32:in `block (2 levels) in initialize'
```
