### PR TITLE
rpmbuild: fix hva package dependency.

### DIFF
--- a/rpmbuild/SPECS/wakame-vdc.spec
+++ b/rpmbuild/SPECS/wakame-vdc.spec
@@ -185,6 +185,7 @@ Requires: openvswitch
 Requires: kpartx
 Requires: libcgroup
 Requires: tunctl
+Requires: sysstat
 # Trema/racket gem binary dependency
 Requires: sqlite libpcap
 Requires: pv


### PR DESCRIPTION
the resource capture depends on pidstat command.

```
##STDERR=>
/bin/bash: pidstat: command not found
/opt/axsh/wakame-vdc/dcmgr/lib/dcmgr/monitor/resource_capture.rb:46:in `block in get_resources': undefined method `merge' for nil:NilClass (NoMethodError)
        from /opt/axsh/wakame-vdc/dcmgr/lib/dcmgr/monitor/resource_capture.rb:24:in `each'
        from /opt/axsh/wakame-vdc/dcmgr/lib/dcmgr/monitor/resource_capture.rb:24:in `get_resources'
        from /opt/axsh/wakame-vdc/dcmgr/lib/dcmgr/node_modules/monitor.rb:25:in `block (4 levels) in <class:Monitor>'
        from /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/bundler/gems/eventmachine-dc84f883b00f/lib/eventmachine.rb:1037:in `call'
        from /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/bundler/gems/eventmachine-dc84f883b00f/lib/eventmachine.rb:1037:in `block in spawn_threadpool'
```
