### PR TITLE
natbox: fix NameError.

### DIFF
--- a/dcmgr/lib/dcmgr/configurations/natbox.rb
+++ b/dcmgr/lib/dcmgr/configurations/natbox.rb
@@ -8,7 +8,7 @@ module Dcmgr
 
     class Natbox < Fuguta::Configuration
 
-      class DcNetwork < Configuration
+      class DcNetwork < Fuguta::Configuration
         param :interface
         param :bridge
 


### PR DESCRIPTION
```
/opt/axsh/wakame-vdc/dcmgr/lib/dcmgr/configurations/natbox.rb:11:in `<class:Natbox>': uninitialized constant Dcmgr::Configurations::Natbox::Configuration (NameError)
        from /opt/axsh/wakame-vdc/dcmgr/lib/dcmgr/configurations/natbox.rb:9:in `<module:Configurations>'
        from /opt/axsh/wakame-vdc/dcmgr/lib/dcmgr/configurations/natbox.rb:7:in `<module:Dcmgr>'
        from /opt/axsh/wakame-vdc/dcmgr/lib/dcmgr/configurations/natbox.rb:5:in `<top (required)>'
        from ./bin/natbox:19:in `block in <main>'
        from ./bin/natbox:18:in `instance_eval'
        from ./bin/natbox:18:in `<main>'
```
