### PR TITLE
Version requirement for openvswitch in rpmbuild

### DIFF
--- a/rpmbuild/SPECS/wakame-vdc.spec
+++ b/rpmbuild/SPECS/wakame-vdc.spec
@@ -180,8 +180,8 @@ Requires: iscsi-initiator-utils scsi-target-utils
 Requires: ebtables iptables ethtool vconfig iproute
 Requires: bridge-utils
 Requires: dracut-kernel
-Requires: kmod-openvswitch
-Requires: openvswitch
+Requires: kmod-openvswitch = 1.6.1-1
+Requires: openvswitch = 1.6.1-1
 Requires: kpartx
 Requires: libcgroup
 Requires: tunctl
@@ -248,8 +248,8 @@ Group: Development/Languages
 Requires: %{oname} = %{version}-%{release}
 Requires: keepalived
 Requires: bridge-utils
-Requires: kmod-openvswitch
-Requires: openvswitch
+Requires: kmod-openvswitch = 1.6.1-1
+Requires: openvswitch = 1.6.1-1
 %description  natbox-vmapp-config
 <insert long description, indented with spaces>
 


### PR DESCRIPTION
So we can enable the higher version package in our 3rd party repository without affecting vdc.
