### PR TITLE
Allow hva to run hook script for local firewall rule at startup time.

### DIFF
--- a/dcmgr/lib/dcmgr/configurations/hva.rb
+++ b/dcmgr/lib/dcmgr/configurations/hva.rb
@@ -157,6 +157,7 @@ module Dcmgr
       param :logging_service_reload, :default => '/etc/init.d/td-agent reload'
       param :enable_gre, :default=>false
       param :enable_subnet, :default=>false
+      param :netfilter_script_post_flush, :default=>nil
 
       param :brctl_path, :default => '/usr/sbin/brctl'
       param :ovs_run_dir, :default=>'/usr/var/run/openvswitch'

--- a/dcmgr/lib/dcmgr/node_modules/service_netfilter.rb
+++ b/dcmgr/lib/dcmgr/node_modules/service_netfilter.rb
@@ -51,6 +51,11 @@ module Dcmgr
           puts cmds.join("\n") if Dcmgr.conf.verbose_netfilter
           system(cmds.join("\n"))
 
+          if Dcmgr.conf.netfilter_script_post_flush
+            logger.info("Applying iptables/ebtables rules from: #{Dcmgr.conf.netfilter_script_post_flush}")
+            system(Dcmgr.conf.netfilter_script_post_flush)
+          end
+
           @task_manager.apply_tasks([Dcmgr::VNet::Tasks::DebugIptables.new]) if Dcmgr.conf.debug_iptables
 
           (@cache.get_all_local_vnics + @cache.get_all_empty_vnics).each { |vif|


### PR DESCRIPTION
In hva.conf:

```
config.netfilter_script_post_flush = '/etc/init.d/iptables restart'
```

will apply rules written in /etc/sysconfig/iptables when hva starts.
