### PR TITLE
Allow arbitrary conf path location to dcmgr agents.

### DIFF
--- a/dcmgr/bin/backup-cleaner
+++ b/dcmgr/bin/backup-cleaner
@@ -8,7 +8,7 @@ require 'dcmgr'
 require 'isono'
 require 'fuguta'
 
-path = ['/etc/wakame-vdc/dcmgr.conf', File.expand_path('config/dcmgr.conf', Dcmgr::DCMGR_ROOT)].find { |i| File.exists?(i) }
+path = [ENV['CONF_PATH'].to_s, '/etc/wakame-vdc/dcmgr.conf', File.expand_path('config/dcmgr.conf', Dcmgr::DCMGR_ROOT)].find { |i| File.exists?(i) }
 abort("ERROR: Failed to load dcmgr.conf") if path.nil?
 
 begin

--- a/dcmgr/bin/bksta
+++ b/dcmgr/bin/bksta
@@ -16,7 +16,7 @@ require 'fuguta'
 
 include Isono::Runner::RpcServer
 
-path = ['/etc/wakame-vdc/bksta.conf', File.expand_path('config/bksta.conf', Dcmgr::DCMGR_ROOT)].find { |i| File.exists?(i) }
+path = [ENV['CONF_PATH'].to_s, '/etc/wakame-vdc/bksta.conf', File.expand_path('config/bksta.conf', Dcmgr::DCMGR_ROOT)].find { |i| File.exists?(i) }
 abort("ERROR: Failed to load bksta.conf") if path.nil?
 
 begin

--- a/dcmgr/bin/collector
+++ b/dcmgr/bin/collector
@@ -8,7 +8,8 @@ require 'dcmgr'
 require 'isono'
 
 Dcmgr.load_conf(Dcmgr::Configurations::Dcmgr,
-                ['/etc/wakame-vdc/dcmgr.conf',
+                [ENV['CONF_PATH'].to_s,
+                 '/etc/wakame-vdc/dcmgr.conf',
                  File.expand_path('config/dcmgr.conf', Dcmgr::DCMGR_ROOT)
                 ])
 

--- a/dcmgr/bin/hva
+++ b/dcmgr/bin/hva
@@ -11,7 +11,7 @@ require 'socket'
 
 include Isono::Runner::RpcServer
 
-path = ['/etc/wakame-vdc/hva.conf', File.expand_path('config/hva.conf', Dcmgr::DCMGR_ROOT)].find { |i| File.exists?(i) }
+path = [ENV['CONF_PATH'].to_s, '/etc/wakame-vdc/hva.conf', File.expand_path('config/hva.conf', Dcmgr::DCMGR_ROOT)].find { |i| File.exists?(i) }
 abort("ERROR: Failed to load hva.conf") if path.nil?
 
 begin

--- a/dcmgr/bin/natbox
+++ b/dcmgr/bin/natbox
@@ -11,7 +11,7 @@ require 'fuguta'
 
 include Isono::Runner::RpcServer
 
-path = ['/etc/wakame-vdc/natbox.conf', File.expand_path('config/natbox.conf', Dcmgr::DCMGR_ROOT)].find { |i| File.exists?(i) }
+path = [ENV['CONF_PATH'].to_s, '/etc/wakame-vdc/natbox.conf', File.expand_path('config/natbox.conf', Dcmgr::DCMGR_ROOT)].find { |i| File.exists?(i) }
 abort("ERROR: Failed to load natbox.conf") if path.nil?
 
 begin

--- a/dcmgr/bin/nsa
+++ b/dcmgr/bin/nsa
@@ -206,7 +206,7 @@ manifest.instance_eval do
     c.enable_dnsmasq = true
   end
 
-  path = ['/etc/wakame-vdc/nsa.conf', File.expand_path('config/nsa.conf', Dcmgr::DCMGR_ROOT)].find { |i| File.exists?(i) }
+  path = [ENV['CONF_PATH'].to_s, '/etc/wakame-vdc/nsa.conf', File.expand_path('config/nsa.conf', Dcmgr::DCMGR_ROOT)].find { |i| File.exists?(i) }
   load_config File.expand_path(path, app_root)
 end
 

--- a/dcmgr/bin/nwmongw
+++ b/dcmgr/bin/nwmongw
@@ -62,7 +62,8 @@ end
 include Isono::Runner::RpcServer
 
 Dcmgr.load_conf(Dcmgr::Configurations::Nwmongw,
-                ['/etc/wakame-vdc/nwmongw.conf',
+                [ENV['CONF_PATH'].to_s,
+                 '/etc/wakame-vdc/nwmongw.conf',
                  File.expand_path('config/nwmongw.conf', Dcmgr::DCMGR_ROOT)
                 ])
 

--- a/dcmgr/bin/sta
+++ b/dcmgr/bin/sta
@@ -11,7 +11,7 @@ require 'socket'
 
 include Isono::Runner::RpcServer
 
-path = ['/etc/wakame-vdc/sta.conf', File.expand_path('config/sta.conf', Dcmgr::DCMGR_ROOT)].find { |i| File.exists?(i) }
+path = [ENV['CONF_PATH'].to_s, '/etc/wakame-vdc/sta.conf', File.expand_path('config/sta.conf', Dcmgr::DCMGR_ROOT)].find { |i| File.exists?(i) }
 abort("ERROR: Failed to load sta.conf") if path.nil?
 
 begin

--- a/dcmgr/bin/vdc-manage
+++ b/dcmgr/bin/vdc-manage
@@ -12,7 +12,8 @@ require 'thor/group'
 require 'erb'
 
 Dcmgr.load_conf(Dcmgr::Configurations::Dcmgr,
-                ['/etc/wakame-vdc/dcmgr.conf',
+                [ENV['CONF_PATH'].to_s,
+                 '/etc/wakame-vdc/dcmgr.conf',
                  File.expand_path('config/dcmgr.conf', Dcmgr::DCMGR_ROOT)
                 ])
 Dcmgr.run_initializers('logger', 'sequel')


### PR DESCRIPTION
The path information in "CONF_PATH" variable is used as the top priority load path for dcmgr agents.

```
% CONF_PATH=/etc/hva.conf bundle exec ./bin/hva
```
