### PR TITLE
mussel: temporally disable an instance "stop/start" operation.

### DIFF
--- a/client/mussel/test/acceptance/v12.03/1shot/t.instance.lifecycle.strict.sh
+++ b/client/mussel/test/acceptance/v12.03/1shot/t.instance.lifecycle.strict.sh
@@ -55,7 +55,7 @@ function test_compare_instance_hostname() {
 
 ## running -> stop
 
-function test_stop_instance() {
+function _test_stop_instance() {
   run_cmd instance stop ${instance_uuid} >/dev/null
   assertEquals $? 0
 
@@ -63,19 +63,19 @@ function test_stop_instance() {
   assertEquals $? 0
 }
 
-function test_wait_for_network_not_to_be_ready_after_stopping() {
+function _test_wait_for_network_not_to_be_ready_after_stopping() {
   wait_for_network_not_to_be_ready ${instance_ipaddr}
   assertEquals $? 0
 }
 
-function test_wait_for_sshd_not_to_be_ready_after_stopping() {
+function _test_wait_for_sshd_not_to_be_ready_after_stopping() {
   wait_for_sshd_not_to_be_ready ${instance_ipaddr}
   assertEquals $? 0
 }
 
 ## halted  -> start
 
-function test_start_instance() {
+function _test_start_instance() {
   run_cmd instance start ${instance_uuid} >/dev/null
   assertEquals $? 0
 
@@ -83,17 +83,17 @@ function test_start_instance() {
   assertEquals $? 0
 }
 
-function test_get_instance_ipaddr_after_starting() {
+function _test_get_instance_ipaddr_after_starting() {
   instance_ipaddr=$(run_cmd instance show ${instance_uuid} | hash_value address)
   assertEquals $? 0
 }
 
-function test_wait_for_network_to_be_ready_after_starting() {
+function _test_wait_for_network_to_be_ready_after_starting() {
   wait_for_network_to_be_ready ${instance_ipaddr}
   assertEquals $? 0
 }
 
-function test_wait_for_sshd_to_be_ready_after_starting() {
+function _test_wait_for_sshd_to_be_ready_after_starting() {
   wait_for_sshd_to_be_ready ${instance_ipaddr}
   assertEquals $? 0
 }

--- a/client/mussel/test/component/v12.03/t.instance.sh
+++ b/client/mussel/test/component/v12.03/t.instance.sh
@@ -301,7 +301,7 @@ function test_instance_reboot() {
 
 ### stop
 
-function test_instance_stop() {
+function _test_instance_stop() {
   local cmd=stop
 
   assertEquals "$(cli_wrapper ${namespace} ${cmd} ${uuid})" \
@@ -310,7 +310,7 @@ function test_instance_stop() {
 
 ### start
 
-function test_instance_start() {
+function _test_instance_start() {
   local cmd=start
 
   assertEquals "$(cli_wrapper ${namespace} ${cmd} ${uuid})" \

--- a/client/mussel/test/integration/v12.03/rwx/t.instance.lifecycle.stop-start.sh
+++ b/client/mussel/test/integration/v12.03/rwx/t.instance.lifecycle.stop-start.sh
@@ -13,7 +13,7 @@
 
 ## functions
 
-function test_stop_instance() {
+function _test_stop_instance() {
   # :state: stopping
   # :status: online
   run_cmd instance stop ${instance_uuid} >/dev/null
@@ -25,7 +25,7 @@ function test_stop_instance() {
   assertEquals $? 0
 }
 
-function test_start_instance() {
+function _test_start_instance() {
   # :state: initializing
   # :status: online
   run_cmd instance start ${instance_uuid} >/dev/null

--- a/client/mussel/test/unit/v12.03/t.instance.sh
+++ b/client/mussel/test/unit/v12.03/t.instance.sh
@@ -25,7 +25,7 @@ function setUp() {
 function test_instance_help_stderr_to_stdout_success() {
   extract_args ${namespace} help
   res=$(run_cmd  ${MUSSEL_ARGS} 2>&1)
-  assertEquals "$0 ${namespace} [help|backup|backup_volume|create|destroy|index|poweroff|poweron|reboot|show|show_volumes|start|stop|xcreate]" "${res}"
+  assertEquals "$0 ${namespace} [help|backup|backup_volume|create|destroy|index|poweroff|poweron|reboot|show|show_volumes|xcreate]" "${res}"
 }
 
 ### index
@@ -73,13 +73,13 @@ function test_instance_reboot_uuid() {
 
 ### stop
 
-function test_instance_stop_no_uuid() {
+function _test_instance_stop_no_uuid() {
   extract_args ${namespace} stop
   run_cmd ${MUSSEL_ARGS} 2>/dev/null
   assertNotEquals $? 0
 }
 
-function test_instance_stop_uuid() {
+function _test_instance_stop_uuid() {
   extract_args ${namespace} stop i-xxx
   run_cmd ${MUSSEL_ARGS}
   assertEquals $? 0
@@ -87,26 +87,26 @@ function test_instance_stop_uuid() {
 
 ### start
 
-function test_instance_start_no_uuid() {
+function _test_instance_start_no_uuid() {
   extract_args ${namespace} start
   run_cmd ${MUSSEL_ARGS} 2>/dev/null
   assertNotEquals $? 0
 }
 
-function test_instance_start_uuid() {
+function _test_instance_start_uuid() {
   extract_args ${namespace} start i-xxx
   run_cmd ${MUSSEL_ARGS}
   assertEquals $? 0
 }
 
 ### poweroff
-function test_instance_poweroff_no_uuid() {
+function _test_instance_poweroff_no_uuid() {
   extract_args ${namespace} poweroff
   run_cmd ${MUSSEL_ARGS} 2>/dev/null
   assertNotEquals $? 0
 }
 
-function test_instance_poweroff_uuid() {
+function _test_instance_poweroff_uuid() {
   extract_args ${namespace} poweroff i-xxx
   run_cmd ${MUSSEL_ARGS}
   assertEquals $? 0

--- a/client/mussel/v12.03.d/instance.sh
+++ b/client/mussel/v12.03.d/instance.sh
@@ -70,11 +70,11 @@ task_reboot() {
   cmd_put $*
 }
 
-task_stop() {
+_task_stop() {
   cmd_put $*
 }
 
-task_start() {
+_task_start() {
   cmd_put $*
 }
 


### PR DESCRIPTION
temporally disable an instance "stop/start" operation for local-volume.
