### PR TITLE
mussel: add "hash" to param type.

### DIFF
--- a/client/mussel/functions
+++ b/client/mussel/functions
@@ -121,6 +121,7 @@ function add_param() {
      array) local i; for i in \${${param_key}}; do echo "${param_key}[]=\${i}"; done ;;
    strfile) strfile_type ${param_key}            ;;
   strplain) echo "\${${param_key}}" ;;
+      hash) local i; for i in \${${param_key}}; do echo \${param_key}[\${i%%=*}]=\${i##*=}; done ;;
    esac
   "
 }

--- a/client/mussel/test/unit/functions/t.add_param.sh
+++ b/client/mussel/test/unit/functions/t.add_param.sh
@@ -55,6 +55,17 @@ function test_add_param_key_strplain() {
   assertEquals "$(add_param name strplain)" "${name}"
 }
 
+function test_add_param_key_hash() {
+  local name="inst_id=i-xxx"
+  assertEquals "$(add_param name hash)" "name[inst_id]=i-xxx"
+}
+
+function test_add_param_key_hash_multi() {
+  local name="inst_id=i-xxx addr=bar"
+  assertEquals "$(add_param name hash)" "name[inst_id]=i-xxx
+name[addr]=bar"
+}
+
 ## shunit2
 
 . ${shunit2_file}


### PR DESCRIPTION
enable to define "hash" type.
