### PR TITLE
sysvinit: immediately stop vdc agents on stopping system.

### DIFF
--- a/contrib/etc/init.d/vdc-net-event
+++ b/contrib/etc/init.d/vdc-net-event
@@ -3,7 +3,7 @@
 # for RHEL6
 
 ###
-# chkconfig: 2345 99 89
+# chkconfig: 2345 99 1
 # description: vdc-net-event startup script.
 ###
 


### PR DESCRIPTION
for rhel compat.
- change stop priority from 89 to 1.
- vdc-xxx agents should be stopped before vz stopping.
