### PR TITLE
mussel,test: add uuid index limit for long term running node.

### DIFF
--- a/client/mussel/test/integration/v12.03/helper_shunit2.sh
+++ b/client/mussel/test/integration/v12.03/helper_shunit2.sh
@@ -68,7 +68,7 @@ function step_base_show_uuids() {
   while read uuid; do
     run_cmd ${namespace} show ${uuid} >/dev/null
     assertEquals 0 $?
-  done < <(base_index_uuids)
+  done < <(base_index_uuids | head)
 }
 
 function step_base_show_invalid_uuid_syntax() {


### PR DESCRIPTION
an issue on canary node (long term running node).
1. `base_index_uuids` shows many `:id:`
2. then previous-version while-loop calls "show ${uuid}" many times...

this change adds limit using `head` comand to the output of `base_index_uuids`.
