### PR TITLE
mussel: change "account_id" parameter policy from requried to optional.

### DIFF
--- a/client/mussel/functions
+++ b/client/mussel/functions
@@ -83,7 +83,9 @@ function curl_opts() {
 }
 
 function request_header() {
-  echo -H X_VDC_ACCOUNT_UUID:${account_id}
+  if [[ -n "${account_id}" ]]; then
+    echo -H X_VDC_ACCOUNT_UUID:${account_id}
+  fi
 }
 
 function request_param() {

--- a/client/mussel/test/unit/functions/t.request_header.sh
+++ b/client/mussel/test/unit/functions/t.request_header.sh
@@ -19,7 +19,11 @@ function setUp() {
 ### opts
 
 function test_request_header() {
-  assertEquals "$(request_header)" "-H X_VDC_ACCOUNT_UUID:${account_id}"
+  assertEquals "-H X_VDC_ACCOUNT_UUID:${account_id}" "$(request_header)"
+}
+
+function test_request_header_empty_id() {
+  assertEquals "" "$(account_id= request_header)"
 }
 
 ## shunit2


### PR DESCRIPTION
in order to call api without account_id.
