### PR TITLE
kvm: fix guest device order for metadata drive.

### DIFF
--- a/dcmgr/lib/dcmgr/drivers/kvm.rb
+++ b/dcmgr/lib/dcmgr/drivers/kvm.rb
@@ -141,7 +141,9 @@ module Dcmgr
           cmd << qemu_drive_options(hc, v)
           # attach metadata drive
           if inst[:boot_volume_id] == v[:uuid]
-            cmd << "-drive file=#{hc.metadata_img_path},media=disk,boot=off,index=1,cache=none,if=#{drive_model(hc)}"
+            cmd << "-drive file=#{hc.metadata_img_path},id=metadata-drive,cache=none,aio=native,if=none"
+            # guess secondary drive device name for metadata drive.
+            cmd << qemu_drive_options(hc, {guest_device_name: v[:guest_device_name].succ, uuid: 'metadata'})
           end
         }
         


### PR DESCRIPTION
Original -drive qemu option for metadata drive:

```
-device virtio-blk-pci,id=vol-0d9jcrs8,drive=vol-0d9jcrs8-drive,bootindex=0,bus=pci.0,addr=0x4
-drive file=/var/lib/wakame-vdc/instances/i-66o7une9/metadata.img,media=disk,boot=off,index=1,cache=none,if=virtio
-drive file=/var/lib/wakame-vdc/instances/i-66o7une9/vol-04gjv8j4,id=vol-04gjv8j4-drive,cache=none,aio=native,if=none
-device　virtio-blk-pci,id=vol-04gjv8j4,drive=vol-04gjv8j4-drive,bus=pci.0,addr=0x6
```

After this change:

```
-drive file=/home/katsuo/dev/wakame-vdc/tmp/instances/i-2rhofebz/vol-1uai6hwu,id=vol-1uai6hwu-drive,cache=none,aio=native,if=none
-device virtio-blk-pci,id=vol-1uai6hwu,drive=vol-1uai6hwu-drive,bootindex=0,bus=pci.0,addr=0x4
-drive file=/home/katsuo/dev/wakame-vdc/tmp/instances/i-2rhofebz/metadata.img,id=metadata-drive,cache=none,aio=native,if=none
-device virtio-blk-pci,id=metadata,drive=metadata-drive,bus=pci.0,addr=0x5
-drive file=/home/katsuo/dev/wakame-vdc/tmp/instances/i-2rhofebz/vol-pogjgjt8,id=vol-pogjgjt8-drive,cache=none,aio=native,if=none
-device virtio-blk-pci,id=vol-pogjgjt8,drive=vol-pogjgjt8-drive,bus=pci.0,addr=0x6
```
