### PR TITLE
Softoweroff test scenario

### DIFF
--- a/client/mussel/test/acceptance/v12.03/1shot/t.instance.lifecycle.force-poweroff-halting-instance.sh
+++ b/client/mussel/test/acceptance/v12.03/1shot/t.instance.lifecycle.force-poweroff-halting-instance.sh
@@ -57,7 +57,6 @@ function test_force_poweroff_halting_instance() {
   assertEquals 0 $?
 
   # stop acpid
-  remove_ssh_known_host_entry ${instance_ipaddr}
   remote_sudo=$(remote_sudo)
   ssh ${ssh_user}@${instance_ipaddr} -i ${ssh_key_pair_path} "${remote_sudo} /etc/init.d/acpid stop"
   assertEquals 0 $?


### PR DESCRIPTION
environment
1. `kvm` driver
2. non-root ssh login (depends on vmimage)

if non-root ssh login, `/etc/init.d/acpid stop` fails.
