### PR TITLE
mussel,test: fix sourced type sciprt.

### DIFF
--- a/client/mussel/test/acceptance/v12.03/lb-cluster/t.lb.http.node.multi.sh
+++ b/client/mussel/test/acceptance/v12.03/lb-cluster/t.lb.http.node.multi.sh
@@ -8,4 +8,6 @@
 ## wrapper
 
 target_instance_num=${target_instance_num:-3}
-. ${BASH_SOURCE[0]%/*}/t.lb.http.node.single.sh
+# set SHUNIT_PARENT to sourced file to make sure to run test_xx functions in sourced file.
+SHUNIT_PARENT=${BASH_SOURCE[0]%/*}/t.lb.http.node.single.sh
+. ${SHUNIT_PARENT}

--- a/client/mussel/test/acceptance/v12.03/lb-cluster/t.lb.https.node.multi.sh
+++ b/client/mussel/test/acceptance/v12.03/lb-cluster/t.lb.https.node.multi.sh
@@ -8,4 +8,6 @@
 ## wrapper
 
 target_instance_num=${target_instance_num:-3}
-. ${BASH_SOURCE[0]%/*}/t.lb.https.node.single.sh
+# set SHUNIT_PARENT to sourced file to make sure to run test_xx functions in sourced file.
+SHUNIT_PARENT=${BASH_SOURCE[0]%/*}/t.lb.https.node.single.sh
+. ${SHUNIT_PARENT}

--- a/client/mussel/test/acceptance/v12.03/lb-cluster/t.lb.ssl.node.multi.sh
+++ b/client/mussel/test/acceptance/v12.03/lb-cluster/t.lb.ssl.node.multi.sh
@@ -8,4 +8,6 @@
 ## wrapper
 
 target_instance_num=${target_instance_num:-3}
-. ${BASH_SOURCE[0]%/*}/t.lb.ssl.node.single.sh
+# set SHUNIT_PARENT to sourced file to make sure to run test_xx functions in sourced file.
+SHUNIT_PARENT=${BASH_SOURCE[0]%/*}/t.lb.ssl.node.single.sh
+. ${SHUNIT_PARENT}

--- a/client/mussel/test/acceptance/v12.03/lb-cluster/t.lb.tcp.node.multi.sh
+++ b/client/mussel/test/acceptance/v12.03/lb-cluster/t.lb.tcp.node.multi.sh
@@ -8,4 +8,6 @@
 ## wrapper
 
 target_instance_num=${target_instance_num:-3}
-. ${BASH_SOURCE[0]%/*}/t.lb.tcp.node.single.sh
+# set SHUNIT_PARENT to sourced file to make sure to run test_xx functions in sourced file.
+SHUNIT_PARENT=${BASH_SOURCE[0]%/*}/t.lb.tcp.node.single.sh
+. ${SHUNIT_PARENT}

--- a/client/mussel/test/acceptance/v12.03/local-volume-instance/t.volume.local.big-vol.sh
+++ b/client/mussel/test/acceptance/v12.03/local-volume-instance/t.volume.local.big-vol.sh
@@ -8,4 +8,6 @@
 ## wrapper
 
 blank_volume_size=${blank_volume_size:-10G}
-. ${BASH_SOURCE[0]%/*}/t.volume.local.base.sh
+# set SHUNIT_PARENT to sourced file to make sure to run test_xx functions in sourced file.
+SHUNIT_PARENT=${BASH_SOURCE[0]%/*}/t.volume.local.base.sh
+. ${SHUNIT_PARENT}


### PR DESCRIPTION
set `SHUNIT_PARENT`
- make sure to run test_xxx function(s) in source file.
