### PR TITLE
mussel: enable to set network_id with vifs_eth0_network_id shell-variabl...

### DIFF
--- a/client/mussel/test/integration/v12.03/rw/t.ip_handle.sh
+++ b/client/mussel/test/integration/v12.03/rw/t.ip_handle.sh
@@ -13,7 +13,7 @@
 ip_pool_id=
 dc_networks="public"
 display_name="shunit2"
-network_id=nw-demo1
+network_id=${vifs_eth0_network_id:-nw-demo1} # `POST /ip_pool/` required parameter
 ip_handle_id=
 
 ## functions

--- a/client/mussel/test/integration/v12.03/rw/t.ip_pool.sh
+++ b/client/mussel/test/integration/v12.03/rw/t.ip_pool.sh
@@ -13,7 +13,7 @@
 ip_pool_id=
 dc_networks="public"
 display_name="shunit2"
-network_id=nw-demo1
+network_id=${vifs_eth0_network_id:-nw-demo1} # `POST /ip_pool/` required parameter
 ip_handle_id=
 
 ## functions


### PR DESCRIPTION
enable to define `ip_handle`.`network_id` with `vifs_eth0_network_id` in `MUSSEL_RC`
