### PR TITLE
Fix for load balancer service type 

### DIFF
--- a/dcmgr/lib/dcmgr/models/instance.rb
+++ b/dcmgr/lib/dcmgr/models/instance.rb
@@ -389,12 +389,15 @@ module Dcmgr::Models
       # null column.
       boot_volume = image.create_volume(account)
       
-      instance = self.new &blk
+      instance = self.new
       instance.account_id = account.canonical_uuid
       instance.image = image
       instance.request_params = params.dup
       instance.service_type = image.service_type
       instance.boot_volume_id = boot_volume.canonical_uuid
+      if blk
+        blk.call(instance)
+      end
       # Determine primary key number.
       instance.save
 


### PR DESCRIPTION
Load balancer instances got ``std`` service type value set in the following condition:

Image entry for load balancer instance is registered with service_type=std


Models::Instance#entry_new takes a block to overwrite values just before insert the row. the line of the block call was wrong position so the service_type field was always copied from images.service_type field.