### PR TITLE
Expose volume ID under /dev/disk/by-id/ for KVM

### DIFF
--- a/dcmgr/lib/dcmgr/drivers/kvm.rb
+++ b/dcmgr/lib/dcmgr/drivers/kvm.rb
@@ -450,7 +450,7 @@ RUN_SH
                        end
         drive_idx = drive_index(volume[:guest_device_name])
         
-        option_str = "#{device_model},id=#{volume[:uuid]},drive=#{volume[:uuid]}-drive"
+        option_str = "#{device_model},id=#{volume[:uuid]},drive=#{volume[:uuid]}-drive,serial=#{volume[:uuid]}"
         if hc.inst[:boot_volume_id] == volume[:uuid]
           option_str += ',bootindex=0'
         end


### PR DESCRIPTION
Users can retrieve attached volume from their guest OS by looking into symbolic link names in /dev/disk/by-id/. 

As we are going to remove guest_device_name parameter from attaching/detaching volume operation, it is needed the way to map between the volume ID and local guest device.
