### PR TITLE
Fix "Problem with the IP address '-j'." message

### DIFF
--- a/dcmgr/lib/dcmgr/vnet/tasks/accept_arp_broadcast.rb
+++ b/dcmgr/lib/dcmgr/vnet/tasks/accept_arp_broadcast.rb
@@ -12,8 +12,6 @@ module Dcmgr
           super()
           self.hva_ip = hva_ip
 
-          # Allow broadcast from the network
-          self.rules << EbtablesRule.new(:filter,:forward,:arp,:incoming,"--protocol arp --arp-opcode Request --arp-ip-dst#{EbtablesRule.log_arp(log_prefix) if enable_logging} -j ACCEPT")
           # Allow broadcast from the host
           self.rules << EbtablesRule.new(:filter,:output,:arp,:outgoing,"--protocol arp --arp-opcode Request --arp-ip-src=#{self.hva_ip} #{EbtablesRule.log_arp(log_prefix) if enable_logging} -j ACCEPT")
         end


### PR DESCRIPTION
Removed a broken and seemingly unneeded rule that was causing the "Problem with the IP address '-j'." message in the log.
