### PR TITLE
Ignore 'guest_device_name' parameter from API.

### DIFF
--- a/dcmgr/lib/dcmgr/endpoints/12.03/instances.rb
+++ b/dcmgr/lib/dcmgr/endpoints/12.03/instances.rb
@@ -352,7 +352,7 @@ Dcmgr::Endpoints::V1203::CoreAPI.namespace '/instances' do
         end
 
         # common parameters
-        ['guest_device_name', 'display_name', 'description'].each { |pname|
+        ['display_name', 'description'].each { |pname|
           if !vparam[pname].blank?
             vol.send("#{pname}=", vparam[pname])
           end

--- a/dcmgr/lib/dcmgr/endpoints/12.03/responses/instance.rb
+++ b/dcmgr/lib/dcmgr/endpoints/12.03/responses/instance.rb
@@ -79,7 +79,6 @@ module Dcmgr::Endpoints::V1203::Responses
         self.volumes_dataset.each { |v|
           h[:volume] << {
             :vol_id => v.canonical_uuid,
-            :guest_device_name => v.guest_device_name,
             :state  => v.state,
           }
         }

--- a/dcmgr/lib/dcmgr/endpoints/12.03/volumes.rb
+++ b/dcmgr/lib/dcmgr/endpoints/12.03/volumes.rb
@@ -189,12 +189,7 @@ Dcmgr::Endpoints::V1203::CoreAPI.namespace '/volumes' do
       raise E::AttachVolumeFailure, "Volume is attached to running instance."
     end
 
-    guest_device_name = nil
-    if !params['guest_device_name'].blank?
-      guest_device_name = params['guest_device_name']
-    end
-
-    v.attach_to_instance(i, guest_device_name)
+    v.attach_to_instance(i)
 
     case i.state
     when C::Instance::STATE_RUNNING


### PR DESCRIPTION
This PR is just for disabling `guest_device_name` parameter from API side. Will change the place where deals with its database value in later PR.  
