### PR TITLE
fix http_parser.rb 0.5.3.

### DIFF
--- a/dolphin/Gemfile
+++ b/dolphin/Gemfile
@@ -2,6 +2,18 @@ source 'https://rubygems.org'
 
 gem 'wakame-dolphin', '0.0.5'
 
+# *** work-around ***
+#
+# sub package dependency for wakame-dolphin 0.0.5
+#
+# wakame-dolphin (0.0.5)
+#   reel (0.3.0)
+#     http_parser.rb # should be 0.5.3
+#
+# in wakame-dolphin.gemspec, http_parser.rb version is not fixed.
+#
+gem 'http_parser.rb', '0.5.3'
+
 # 1. vdc-dolphin requires gem packages
 # 2. *should be* same version of wakame-dolphin/Gemfile
 


### PR DESCRIPTION
after fixing http_parser.rb version `0.5.3`, client gets success.

```
$ curl -fsSkL http://10.0.2.15:9004/events
{"results":[],"message":"OK"}
```

when using http_parser.rb latest version, dolphin-server got following errors.

```
[centos@wakame-vdc-1box ~]$ less /var/log/wakame-vdc/dolphin.log
I, [2014-05-28T16:20:03.028039 #2325]  INFO -- : [69961343868560] [Dolphin::RequestHandler] Load settings in /etc/wakame-vdc/dolphin.conf
I, [2014-05-28T16:20:03.271816 #2325]  INFO -- : [69961343868560] [Dolphin::RequestHandler] Running on ruby 2.0.0 with selected Celluloid::TaskFiber
I, [2014-05-28T16:20:03.271974 #2325]  INFO -- : [69961343868560] [Dolphin::RequestHandler] Listening on http://0.0.0.0:9004
E, [2014-05-29T00:15:45.631617 #2325] ERROR -- : Reel::RackWorker crashed!
NoMethodError: undefined method `request_path' for #<HTTP::Parser:0x007f424940d840>
/opt/axsh/wakame-vdc/dolphin/vendor/bundle/ruby/2.0.0/gems/reel-0.3.0/lib/reel/request_parser.rb:14:in `block (2 levels) in <class:Parser>'
/opt/axsh/wakame-vdc/dolphin/vendor/bundle/ruby/2.0.0/gems/reel-0.3.0/lib/reel/mixins.rb:50:in `path'
/opt/axsh/wakame-vdc/dolphin/vendor/bundle/ruby/2.0.0/gems/reel-0.3.0/lib/reel/rack_worker.rb:120:in `env'
/opt/axsh/wakame-vdc/dolphin/vendor/bundle/ruby/2.0.0/gems/reel-0.3.0/lib/reel/rack_worker.rb:84:in `request_env'
/opt/axsh/wakame-vdc/dolphin/vendor/bundle/ruby/2.0.0/gems/reel-0.3.0/lib/reel/rack_worker.rb:73:in `handle_request'
/opt/axsh/wakame-vdc/dolphin/vendor/bundle/ruby/2.0.0/gems/reel-0.3.0/lib/reel/rack_worker.rb:65:in `handle'
/opt/axsh/wakame-vdc/dolphin/vendor/bundle/ruby/2.0.0/gems/celluloid-0.12.4/lib/celluloid/calls.rb:23:in `public_send'
/opt/axsh/wakame-vdc/dolphin/vendor/bundle/ruby/2.0.0/gems/celluloid-0.12.4/lib/celluloid/calls.rb:23:in `dispatch'
/opt/axsh/wakame-vdc/dolphin/vendor/bundle/ruby/2.0.0/gems/celluloid-0.12.4/lib/celluloid/actor.rb:327:in `block in handle_message'
/opt/axsh/wakame-vdc/dolphin/vendor/bundle/ruby/2.0.0/gems/celluloid-0.12.4/lib/celluloid/tasks/task_fiber.rb:24:in `block in initialize'
E, [2014-05-29T00:15:52.291779 #2325] ERROR -- : Reel::RackWorker crashed!
NoMethodError: undefined method `request_path' for #<HTTP::Parser:0x007f424a17f208>
/opt/axsh/wakame-vdc/dolphin/vendor/bundle/ruby/2.0.0/gems/reel-0.3.0/lib/reel/request_parser.rb:14:in `block (2 levels) in <class:Parser>'
/opt/axsh/wakame-vdc/dolphin/vendor/bundle/ruby/2.0.0/gems/reel-0.3.0/lib/reel/mixins.rb:50:in `path'
/opt/axsh/wakame-vdc/dolphin/vendor/bundle/ruby/2.0.0/gems/reel-0.3.0/lib/reel/rack_worker.rb:120:in `env'
/opt/axsh/wakame-vdc/dolphin/vendor/bundle/ruby/2.0.0/gems/reel-0.3.0/lib/reel/rack_worker.rb:84:in `request_env'
/opt/axsh/wakame-vdc/dolphin/vendor/bundle/ruby/2.0.0/gems/reel-0.3.0/lib/reel/rack_worker.rb:73:in `handle_request'
/opt/axsh/wakame-vdc/dolphin/vendor/bundle/ruby/2.0.0/gems/reel-0.3.0/lib/reel/rack_worker.rb:65:in `handle'
/opt/axsh/wakame-vdc/dolphin/vendor/bundle/ruby/2.0.0/gems/celluloid-0.12.4/lib/celluloid/calls.rb:23:in `public_send'
/opt/axsh/wakame-vdc/dolphin/vendor/bundle/ruby/2.0.0/gems/celluloid-0.12.4/lib/celluloid/calls.rb:23:in `dispatch'
/opt/axsh/wakame-vdc/dolphin/vendor/bundle/ruby/2.0.0/gems/celluloid-0.12.4/lib/celluloid/actor.rb:327:in `block in handle_message'
/opt/axsh/wakame-vdc/dolphin/vendor/bundle/ruby/2.0.0/gems/celluloid-0.12.4/lib/celluloid/tasks/task_fiber.rb:24:in `block in initialize'
```
