### PR TITLE
Fix unexpected validation issue of volume model

### DIFF
--- a/dcmgr/lib/dcmgr/models/volume.rb
+++ b/dcmgr/lib/dcmgr/models/volume.rb
@@ -61,7 +61,8 @@ module Dcmgr::Models
 
       errors.add(:size, "Invalid volume size: #{self.size}") if self.size < 0
 
-      if self.instance
+      # test column value directly because associated model object might be cached.
+      if !self.instance_id.nil?
         # check if volume parameters are conformant for hypervisor.
         hypervisor_class = Dcmgr::Drivers::Hypervisor.driver_class(self.instance.hypervisor.to_sym)
         hypervisor_class.policy.validate_volume_model(self)


### PR DESCRIPTION
It seems that the model class validation runs for unexpected case due to the association model object caching. 

API returns following trace when calls detach volume operation for halted instance.

```
Sequel::ValidationFailed - guest_device_name require to have device name:
/opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/sequel-3.47.0/lib/sequel/model/base.rb:1308:in `save'
/opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/sequel-3.47.0/lib/sequel/model/associations.rb:1401:in `block in def_one_to_many'
/opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/sequel-3.47.0/lib/sequel/model/associations.rb:1638:in `remove_associated_object'
/opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/sequel-3.47.0/lib/sequel/model/associations.rb:1423:in `block in def_remove_methods'
/opt/axsh/wakame-vdc/dcmgr/lib/dcmgr/models/volume.rb:234:in `detach_from_instance'
/opt/axsh/wak
ame-vdc/dcmgr/lib/dcmgr/endpoints/12.03/volumes.rb:240:in `block (2 levels) in load_namespace'
```
