### PR TITLE
Windows password database fix

### DIFF
--- a/dcmgr/config/db/migrations/0020_windows_support.rb
+++ b/dcmgr/config/db/migrations/0020_windows_support.rb
@@ -7,7 +7,7 @@ Sequel.migration do
     end
 
     alter_table(:instances) do
-      add_column :encrypted_password, "varchar(255)"
+      add_column :encrypted_password, "text"
     end
   end
 


### PR DESCRIPTION
The database column for Windows' encrypted password wasn't long enough to hold the password so I changed its type to text.
