### PR TITLE
Revert "mussel: add or_fail_with option to retry functions."

### DIFF
--- a/client/mussel/test/helpers/retry.sh
+++ b/client/mussel/test/helpers/retry.sh
@@ -7,34 +7,17 @@
 ## retry
 
 function retry_until() {
-  local chk_cmd="$1"
-  shift;
+  local blk="$@"
+
   local wait_sec=${RETRY_WAIT_SEC:-120}
   local sleep_sec=${RETRY_SLEEP_SEC:-3}
-  local tries=0 fail_chk_cmd=
+  local tries=0
   local start_at=$(date +%s)
 
-  while [[ "$#" -gt 0 ]]; do
-    case "$1" in
-      or_fail_with | --fail_with)
-        fail_chk_cmd="$2"
-        shift;
-        ;;
-    esac
-    shift
-  done
-
   while :; do
-    eval "${chk_cmd}" && {
+    eval "${blk}" && {
       break
     } || {
-      if [[ -n "${fail_chk_cmd}" ]]; then
-        eval "${fail_chk_cmd}";
-        if [[ "$?" -eq 0 ]]; then
-          echo "Detected failure case: eval:${fail_chk_cmd}" >&2
-          return 2
-        fi
-      fi
       sleep ${sleep_sec}
     }
 
@@ -48,9 +31,8 @@ function retry_until() {
 }
 
 function retry_while() {
-  local blk="$1"
-  shift;
-  retry_until "! ${blk}" $@
+  local blk="$@"
+  retry_until ! ${blk}
 }
 
 ## check


### PR DESCRIPTION
This reverts commit 0b1caf7462ad6251bf72576d56d0fe0da16851ce.
