### PR TITLE
fix undefined method reference.

### DIFF
--- a/dcmgr/lib/dcmgr/rpc/hva_handler.rb
+++ b/dcmgr/lib/dcmgr/rpc/hva_handler.rb
@@ -317,9 +317,9 @@ module Dcmgr
         if @inst[:volume].values.all?{|v| v[:state].to_s == 'available'}
           # boot instance becase all volumes are ready.
           if @inst[:volume][@inst[:boot_volume_id]][:volume_type] == 'Dcmgr::Model::LocalVolume'
-            job.submit("hva-handle.#{node.node_id}", 'run_local_store', @inst[:uuid])
+            job.submit("hva-handle.#{@node.node_id}", 'run_local_store', @inst[:uuid])
           else
-            job.submit("hva-handle.#{node.node_id}", 'run_vol_store', @inst[:uuid])
+            job.submit("hva-handle.#{@node.node_id}", 'run_vol_store', @inst[:uuid])
           end
         elsif @inst[:state].to_s == 'terminated' || @inst[:volume].values.find{|v| v[:state].to_s == 'deleted' }
           # it cancels all available volumes.


### PR DESCRIPTION
```
2014-07-02 19:02:10 JobContext thr=JobWorker[0/1] [INFO]: Job start 342b6cf6d3a3ec01629a72ba92dee387c2269013 (Local ID: d20d18b1e68046e750911710f7ad2874079bbf68)[ wait_volu
mes_available ]
2014-07-02 19:03:03 JobContext thr=JobWorker[0/1] [ERROR]: Job failed 342b6cf6d3a3ec01629a72ba92dee387c2269013 [ wait_volumes_available ]: undefined local variable or metho
d `node' for #<Dcmgr::Rpc::HvaHandler:0x007f10195daf90>
2014-07-02 19:03:04 JobContext thr=JobWorker[0/1] [ERROR]: Caught NameError: undefined local variable or method `node' for #<Dcmgr::Rpc::HvaHandler:0x007f10195daf90>
/opt/axsh/wakame-vdc/dcmgr/lib/dcmgr/rpc/hva_handler.rb:323:in `wait_volumes_available'
/opt/axsh/wakame-vdc/dcmgr/lib/dcmgr/rpc/hva_handl
er.rb:339:in `block in <class:HvaHandler>'
        /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/isono-0.2.19/lib/isono/runner/rpc_server.rb:69:in `instance_eval'
        /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/isono-0.2.19/lib/isono/runner/rpc_server.rb:69:in `block in job'
        /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/isono-0.2.19/lib/isono/rack/proc.rb:25:in `instance_eval'
        /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/isono-0.2.19/lib/isono/rack/proc.rb:25:in `call'
        /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/isono-0.2.19/lib/isono/rack/map.rb:52:in `call'
        /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/isono-0.2.19/lib/isono/rack/map.rb:52:in `call'
        /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/isono-0.2.19/lib/isono/rack/builder.rb:36:in `call'
        /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/isono-0.2.19/lib/isono/rack/job.rb:59:in `block (2 levels) in call'
        /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/isono-0.2.19/lib/isono/node_modules/job_worker.rb:67:in `call'
        /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/isono-0.2.19/lib/isono/node_modules/job_worker.rb:67:in `block in start'
        /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/isono-0.2.19/lib/isono/thread_pool.rb:32:in `call'
        /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/isono-0.2.19/lib/isono/thread_pool.rb:32:in `block (2 levels) in initialize'
```
