### PR TITLE
Add empty rspec unit tests

### DIFF
--- a/dcmgr/Gemfile
+++ b/dcmgr/Gemfile
@@ -61,3 +61,7 @@ gem 'dcell', '0.15.0'
 gem 'celluloid', '0.15.2'
 gem 'reel', '0.4.0'
 gem 'http', '0.5.0'
+
+group :test do
+  gem 'rspec'
+end


### PR DESCRIPTION
This adds the rspec gem so we can already add the rspec job to the CI and gradually start writing unit tests. All the CI job needs to do is this:

```
cd /opt/axsh/wakame-vdc/dcmgr
bundle exec rspec
```

Rspec will return exit status zero as it didn't find any examples yet and thus had no failures.
