### PR TITLE
Increase Windows handler thread concurrency

### DIFF
--- a/dcmgr/lib/dcmgr/configurations/hva.rb
+++ b/dcmgr/lib/dcmgr/configurations/hva.rb
@@ -39,7 +39,7 @@ module Dcmgr
       end
 
       class Windows < Fuguta::Configuration
-        param :thread_concurrency, :default=>2
+        param :thread_concurrency, default: 10
 
         param :password_generation_sleeptime, default: 2
         param :password_generation_timeout, default: 60 * 15


### PR DESCRIPTION
When I wrote the Windows handler, I just copied its thread concurrency from another class without thinking about it.

The Windows handler only waits for Windows instances to configure themselves and each thread it spawns waits for another instance so more should be allowed concurrently.
