### PR TITLE
Speed up unit tests

### DIFF
--- a/dcmgr/spec/spec_helper.rb
+++ b/dcmgr/spec/spec_helper.rb
@@ -14,8 +14,11 @@ RSpec.configure do |c|
   c.color     = true
 
   c.before(:suite) do
-    DatabaseCleaner.strategy = :transaction
+    # We truncate the database once before running the entire suite
     DatabaseCleaner.clean_with :truncation
+
+    # We cleanup any data after tests using transactions since it's a lot faster
+    DatabaseCleaner.strategy = :transaction
   end
 
   c.before(:each) do


### PR DESCRIPTION
The database is reset between every test example. Doing it using transactions (that are rolled back) instead of truncating every time makes the tests twice as fast.
