### PR TITLE
Fix kvm tcp port issue

### DIFF
--- a/dcmgr/lib/dcmgr/drivers/kvm.rb
+++ b/dcmgr/lib/dcmgr/drivers/kvm.rb
@@ -607,20 +607,22 @@ RUN_SH
       end
 
       def build_qemu_command(hc)
-        opts = {}
         # Finds three TCP listen ports at a time.
         #   QEMU monitor port, VNC console, Serial console.
-        monitor_tcp_port, opts[:vnc_tcp_port], opts[:serial_tcp_port] =
+        monitor_tcp_port, vnc_tcp_port, serial_tcp_port =
           find_unused_tcp_listen_ports(3)
         hc.dump_instance_parameter('monitor.port', monitor_tcp_port)
 
         # run vm
         inst = hc.inst
+        opts = {}
         if driver_configuration.vnc_options
+          opts[:vnc_tcp_port] = vnc_tcp_port
           hc.dump_instance_parameter('vnc.port', opts[:vnc_tcp_port])
         end
 
         if driver_configuration.serial_port_options
+          opts[:serial_tcp_port] = serial_tcp_port
           hc.dump_instance_parameter('serial.port', opts[:serial_tcp_port])
         end
 


### PR DESCRIPTION
We are getting more qemu's port bind error since after #401.

I found the case that same port number is generated from pick_tcp_listen_port() helper function. so it is changed to be able to return multiple unique unused port numbers.

```
22:46:19 ##STDERR=>
22:46:19 inet_listen_opts: bind(ipv4,127.0.0.1,29921): Address already in use
22:46:19 inet_listen_opts: FAILED
22:46:19 chardev: opening backend "socket" failed
22:46:19 qemu: could not open serial device 'telnet:127.0.0.1:29921,server,nowait': Address already in use
```
