### PR TITLE
fix --volumes[] argument for mussel.sh

### DIFF
--- a/client/mussel/functions
+++ b/client/mussel/functions
@@ -26,7 +26,7 @@ function extract_args() {
         #  V
         # volumes_curl_args="volumes[0][type]=xxxx volumes[0][size]=50G
         key_prefix=${key%%\[*}
-        eval "${key_prefix}_args=\"\$\{${key_prefix}_args\} ${arg##--}\""
+        eval "${key_prefix}_args=\"\${${key_prefix}_args} ${arg##--}\""
       else
         value="${value} ${arg##--*=}"
         eval "${key}=\"${value}\""; value="\${${key}}"; value=$(eval echo ${value}); eval "${key}=\"${value## }\""
@@ -118,24 +118,24 @@ function strfile_type() {
   [[ -n "${key}" ]] || { echo "[ERROR] 'key' is empty (${BASH_SOURCE[0]##*/}:${LINENO})" >&2; return 1; }
 
   eval "
-   if [[ -f "\${${key}}" ]]; then
+   if [[ -f \"\${${key}}\" ]]; then
      # file: key@${key}
-     echo "${key}@\${${key}}"
+     echo \"${key}@\${${key}}\"
    else
      # str: key=${key}
-     echo "${key}=\${${key}}"
+     echo \"${key}=\${${key}}\"
    fi
   "
 }
 
 function add_args_param() {
-  local param_key=$1
+  local param_key="$1"
   [[ -n "${param_key}" ]] || { echo "[ERROR] 'param_key' is empty (${BASH_SOURCE[0]##*/}:${LINENO})" >&2; return 1; }
 
   eval "
-   [[ -n "\${${param_key}_args}" ]] || return 0
+   [[ -n \"\${${param_key}_args}\" ]] || return 0
 
-   local i; for i in \${${param_key}_args}; do echo $(urlencode_data \$i); done
+   local i; for i in \${${param_key}_args}; do echo \$(urlencode_data \$i); done
   "
 }
 
@@ -144,14 +144,14 @@ function add_param() {
   [[ -n "${param_key}" ]] || { echo "[ERROR] 'param_key' is empty (${BASH_SOURCE[0]##*/}:${LINENO})" >&2; return 1; }
 
   eval "
-   [[ -n "\${${param_key}}" ]] || return 0
+   [[ -n \"\${${param_key}}\" ]] || return 0
 
-   case "${param_type}" in
-    string) echo   "${param_key}=\${${param_key}}" ;;
-     array) local i; for i in \${${param_key}}; do echo "${param_key}[]=\${i}"; done ;;
-   strfile) strfile_type ${param_key}            ;;
-  strplain) echo "\${${param_key}}" ;;
-      hash) local i; for i in \${${param_key}}; do echo \${param_key}[\${i%%=*}]=\${i##*=}; done ;;
+   case \"${param_type}\" in
+    string) echo   \"${param_key}=\${${param_key}}\" ;;
+    array) local i; for i in \${${param_key}}; do echo \"${param_key}[]=\${i}\"; done ;;
+    strfile) strfile_type ${param_key}            ;;
+    strplain) echo \"\${${param_key}}\" ;;
+    hash) local i; for i in \${${param_key}}; do echo \${param_key}[\${i%%=*}]=\${i##*=}; done ;;
    esac
   "
 }


### PR DESCRIPTION
mussel arguments which are added by add_args_param() were interpreted to curl command line wrongly.

In functions file, there were some escape missing strings which are supplied to eval.

Example:

```
mussle.sh instance create --volumes[0][size]=10 --volumes[0][type]=shared
```

resulted to:

```
curl -fsSkL --dump-header - -X POST --data-urlencode $\{volumes_args\} --data-urlencode volumes[0][size]=10 http://localhost:9001/api/12.03/instances.yml
```

This is the expected command line comes with this change.

```
curl -fsSkL --dump-header - -X POST --data-urlencode volumes[0][size]=10 http://localhost:9001/api/12.03/instances.yml
```
