### PR TITLE
Fix HA scheduler

### DIFF
--- a/dcmgr/lib/dcmgr/node_modules/scheduler.rb
+++ b/dcmgr/lib/dcmgr/node_modules/scheduler.rb
@@ -181,7 +181,7 @@ module Dcmgr
           failed_instances = []
           skipped_instances = []
           # TODO: Add interface for prioritize moving instances.
-          running_instances_ds = src_host_node.instances_dataset.alives
+          running_instances_ds = src_host_node.instances_dataset.alives.for_update
           running_instances_ds.all.each { |instance|
             if !instance.ha_enabled
               instance.state = :halted


### PR DESCRIPTION
Fix issues below:
- ha_enabled flag has no effect.
- local volume instance causes no method error while it was being calculated.
- poor log message for scheduling result.
