### PR TITLE
upstart conf to check RUN=yes only on auto start.

### DIFF
--- a/contrib/etc/init/vdc-admin.conf
+++ b/contrib/etc/init/vdc-admin.conf
@@ -12,8 +12,9 @@ env NAME=admin
 
 script
     [ -f /etc/default/vdc-${NAME} ] && . /etc/default/vdc-${NAME}
-    [ "x${RUN}" != "xyes" ] && {
-      logger "[${NAME}] ${NAME} will not start. because RUN is not 'yes' in /etc/default/vdc-${NAME}."
+    # Make RUN=yes effective only at auto start.
+    [ -n "$UPSTART_EVENTS" -a "x${RUN}" != "xyes" ] && {
+      logger "[${NAME}] Skip auto start for ${NAME}. Edit /etc/default/vdc-${NAME} to set RUN=yes."
       exit 0
     }
 

--- a/contrib/etc/init/vdc-auth.conf
+++ b/contrib/etc/init/vdc-auth.conf
@@ -12,8 +12,9 @@ env NAME=auth
 
 script
     [ -f /etc/default/vdc-${NAME} ] && . /etc/default/vdc-${NAME}
-    [ "x${RUN}" != "xyes" ] && {
-      logger "[${NAME}] ${NAME} will not start. because RUN is not 'yes' in /etc/default/vdc-${NAME}."
+    # Make RUN=yes effective only at auto start.
+    [ -n "$UPSTART_EVENTS" -a "x${RUN}" != "xyes" ] && {
+      logger "[${NAME}] Skip auto start for ${NAME}. Edit /etc/default/vdc-${NAME} to set RUN=yes."
       exit 0
     }
 

--- a/contrib/etc/init/vdc-bksta.conf
+++ b/contrib/etc/init/vdc-bksta.conf
@@ -12,8 +12,9 @@ env NAME=bksta
 
 script
     [ -f /etc/default/vdc-${NAME} ] && . /etc/default/vdc-${NAME}
-    [ "x${RUN}" != "xyes" ] && {
-      logger "[${NAME}] ${NAME} will not start. because RUN is not 'yes' in /etc/default/vdc-${NAME}."
+    # Make RUN=yes effective only at auto start.
+    [ -n "$UPSTART_EVENTS" -a "x${RUN}" != "xyes" ] && {
+      logger "[${NAME}] Skip auto start for ${NAME}. Edit /etc/default/vdc-${NAME} to set RUN=yes."
       exit 0
     }
 

--- a/contrib/etc/init/vdc-collector.conf
+++ b/contrib/etc/init/vdc-collector.conf
@@ -14,8 +14,9 @@ env NAME=collector
 
 script
     [ -f /etc/default/vdc-${NAME} ] && . /etc/default/vdc-${NAME}
-    [ "x${RUN}" != "xyes" ] && {
-      logger "[${NAME}] ${NAME} will not start. because RUN is not 'yes' in /etc/default/vdc-${NAME}."
+    # Make RUN=yes effective only at auto start.
+    [ -n "$UPSTART_EVENTS" -a "x${RUN}" != "xyes" ] && {
+      logger "[${NAME}] Skip auto start for ${NAME}. Edit /etc/default/vdc-${NAME} to set RUN=yes."
       exit 0
     }
 

--- a/contrib/etc/init/vdc-dcmgr.conf
+++ b/contrib/etc/init/vdc-dcmgr.conf
@@ -12,8 +12,9 @@ env NAME=dcmgr
 
 script
     [ -f /etc/default/vdc-${NAME} ] && . /etc/default/vdc-${NAME}
-    [ "x${RUN}" != "xyes" ] && {
-      logger "[${NAME}] ${NAME} will not start. because RUN is not 'yes' in /etc/default/vdc-${NAME}."
+    # Make RUN=yes effective only at auto start.
+    [ -n "$UPSTART_EVENTS" -a "x${RUN}" != "xyes" ] && {
+      logger "[${NAME}] Skip auto start for ${NAME}. Edit /etc/default/vdc-${NAME} to set RUN=yes."
       exit 0
     }
 

--- a/contrib/etc/init/vdc-dolphin.conf
+++ b/contrib/etc/init/vdc-dolphin.conf
@@ -12,8 +12,9 @@ env NAME=dolphin
 
 script
   [ -f /etc/default/vdc-${NAME} ] && . /etc/default/vdc-${NAME}
-  [ "x${RUN}" != "xyes" ] && {
-    logger "[${NAME}] ${NAME} will not start. because RUN is not 'yes' in /etc/default/vdc-${NAME}."
+  # Make RUN=yes effective only at auto start.
+  [ -n "$UPSTART_EVENTS" -a "x${RUN}" != "xyes" ] && {
+    logger "[${NAME}] Skip auto start for ${NAME}. Edit /etc/default/vdc-${NAME} to set RUN=yes."
     exit 0
   }
 

--- a/contrib/etc/init/vdc-fluentd.conf
+++ b/contrib/etc/init/vdc-fluentd.conf
@@ -14,8 +14,9 @@ env NAME=fluentd
 
 script
     [ -f /etc/default/vdc-${NAME} ] && . /etc/default/vdc-${NAME}
-    [ "x${RUN}" != "xyes" ] && {
-      logger "[${NAME}] ${NAME} will not start. because RUN is not 'yes' in /etc/default/vdc-${NAME}."
+    # Make RUN=yes effective only at auto start.
+    [ -n "$UPSTART_EVENTS" -a "x${RUN}" != "xyes" ] && {
+      logger "[${NAME}] Skip auto start for ${NAME}. Edit /etc/default/vdc-${NAME} to set RUN=yes."
       exit 0
     }
 

--- a/contrib/etc/init/vdc-hma.conf
+++ b/contrib/etc/init/vdc-hma.conf
@@ -12,8 +12,9 @@ env NAME=hma
 
 script
     [ -f /etc/default/vdc-${NAME} ] && . /etc/default/vdc-${NAME}
-    [ "x${RUN}" != "xyes" ] && {
-      logger "[${NAME}] ${NAME} will not start. because RUN is not 'yes' in /etc/default/vdc-${NAME}."
+    # Make RUN=yes effective only at auto start.
+    [ -n "$UPSTART_EVENTS" -a "x${RUN}" != "xyes" ] && {
+      logger "[${NAME}] Skip auto start for ${NAME}. Edit /etc/default/vdc-${NAME} to set RUN=yes."
       exit 0
     }
 

--- a/contrib/etc/init/vdc-hva.conf
+++ b/contrib/etc/init/vdc-hva.conf
@@ -14,8 +14,9 @@ env NAME=hva
 
 script
     [ -f /etc/default/vdc-${NAME} ] && . /etc/default/vdc-${NAME}
-    [ "x${RUN}" != "xyes" ] && {
-      logger "[${NAME}] ${NAME} will not start. because RUN is not 'yes' in /etc/default/vdc-${NAME}."
+    # Make RUN=yes effective only at auto start.
+    [ -n "$UPSTART_EVENTS" -a "x${RUN}" != "xyes" ] && {
+      logger "[${NAME}] Skip auto start for ${NAME}. Edit /etc/default/vdc-${NAME} to set RUN=yes."
       exit 0
     }
 

--- a/contrib/etc/init/vdc-metadata.conf
+++ b/contrib/etc/init/vdc-metadata.conf
@@ -12,8 +12,9 @@ env NAME=metadata
 
 script
     [ -f /etc/default/vdc-${NAME} ] && . /etc/default/vdc-${NAME}
-    [ "x${RUN}" != "xyes" ] && {
-      logger "[${NAME}] ${NAME} will not start. because RUN is not 'yes' in /etc/default/vdc-${NAME}."
+    # Make RUN=yes effective only at auto start.
+    [ -n "$UPSTART_EVENTS" -a "x${RUN}" != "xyes" ] && {
+      logger "[${NAME}] Skip auto start for ${NAME}. Edit /etc/default/vdc-${NAME} to set RUN=yes."
       exit 0
     }
 

--- a/contrib/etc/init/vdc-natbox.conf
+++ b/contrib/etc/init/vdc-natbox.conf
@@ -14,8 +14,9 @@ env NAME=natbox
 
 script
     [ -f /etc/default/vdc-${NAME} ] && . /etc/default/vdc-${NAME}
-    [ "x${RUN}" != "xyes" ] && {
-      logger "[${NAME}] ${NAME} will not start. because RUN is not 'yes' in /etc/default/vdc-${NAME}."
+    # Make RUN=yes effective only at auto start.
+    [ -n "$UPSTART_EVENTS" -a "x${RUN}" != "xyes" ] && {
+      logger "[${NAME}] Skip auto start for ${NAME}. Edit /etc/default/vdc-${NAME} to set RUN=yes."
       exit 0
     }
 

--- a/contrib/etc/init/vdc-nsa.conf
+++ b/contrib/etc/init/vdc-nsa.conf
@@ -12,8 +12,9 @@ env NAME=nsa
 
 script
     [ -f /etc/default/vdc-${NAME} ] && . /etc/default/vdc-${NAME}
-    [ "x${RUN}" != "xyes" ] && {
-      logger "[${NAME}] ${NAME} will not start. because RUN is not 'yes' in /etc/default/vdc-${NAME}."
+    # Make RUN=yes effective only at auto start.
+    [ -n "$UPSTART_EVENTS" -a "x${RUN}" != "xyes" ] && {
+      logger "[${NAME}] Skip auto start for ${NAME}. Edit /etc/default/vdc-${NAME} to set RUN=yes."
       exit 0
     }
 

--- a/contrib/etc/init/vdc-nwmongw.conf
+++ b/contrib/etc/init/vdc-nwmongw.conf
@@ -12,8 +12,9 @@ env NAME=nwmongw
 
 script
     [ -f /etc/default/vdc-${NAME} ] && . /etc/default/vdc-${NAME}
-    [ "x${RUN}" != "xyes" ] && {
-      logger "[${NAME}] ${NAME} will not start. because RUN is not 'yes' in /etc/default/vdc-${NAME}."
+    # Make RUN=yes effective only at auto start.
+    [ -n "$UPSTART_EVENTS" -a "x${RUN}" != "xyes" ] && {
+      logger "[${NAME}] Skip auto start for ${NAME}. Edit /etc/default/vdc-${NAME} to set RUN=yes."
       exit 0
     }
 

--- a/contrib/etc/init/vdc-proxy.conf
+++ b/contrib/etc/init/vdc-proxy.conf
@@ -12,8 +12,9 @@ env NAME=proxy
 
 script
     [ -f /etc/default/vdc-${NAME} ] && . /etc/default/vdc-${NAME}
-    [ "x${RUN}" != "xyes" ] && {
-      logger "[${NAME}] ${NAME} will not start. because RUN is not 'yes' in /etc/default/vdc-${NAME}."
+    # Make RUN=yes effective only at auto start.
+    [ -n "$UPSTART_EVENTS" -a "x${RUN}" != "xyes" ] && {
+      logger "[${NAME}] Skip auto start for ${NAME}. Edit /etc/default/vdc-${NAME} to set RUN=yes."
       exit 0
     }
 

--- a/contrib/etc/init/vdc-sta.conf
+++ b/contrib/etc/init/vdc-sta.conf
@@ -12,8 +12,9 @@ env NAME=sta
 
 script
     [ -f /etc/default/vdc-${NAME} ] && . /etc/default/vdc-${NAME}
-    [ "x${RUN}" != "xyes" ] && {
-      logger "[${NAME}] ${NAME} will not start. because RUN is not 'yes' in /etc/default/vdc-${NAME}."
+    # Make RUN=yes effective only at auto start.
+    [ -n "$UPSTART_EVENTS" -a "x${RUN}" != "xyes" ] && {
+      logger "[${NAME}] Skip auto start for ${NAME}. Edit /etc/default/vdc-${NAME} to set RUN=yes."
       exit 0
     }
 

--- a/contrib/etc/init/vdc-webui.conf
+++ b/contrib/etc/init/vdc-webui.conf
@@ -12,8 +12,9 @@ env NAME=webui
 
 script
     [ -f /etc/default/vdc-${NAME} ] && . /etc/default/vdc-${NAME}
-    [ "x${RUN}" != "xyes" ] && {
-      logger "[${NAME}] ${NAME} will not start. because RUN is not 'yes' in /etc/default/vdc-${NAME}."
+    # Make RUN=yes effective only at auto start.
+    [ -n "$UPSTART_EVENTS" -a "x${RUN}" != "xyes" ] && {
+      logger "[${NAME}] Skip auto start for ${NAME}. Edit /etc/default/vdc-${NAME} to set RUN=yes."
       exit 0
     }
 


### PR DESCRIPTION
#436 discusses the problem about manual start command line and auto start control. I achieved to change upstart confs which do not need RUN=yes for command line and keeps the compatibility with /etc/default files.

The change applies upstart confs to be:
- For manual start, just type `initctl start vdc-xxxx`. any following variables are ignored.
- For auto start, RUN=yes in `/etc/default/vdc-xxxx` is available same as before.
