### PR TITLE
fix to follow renaming flag.

### DIFF
--- a/dcmgr/lib/dcmgr/cli/host.rb
+++ b/dcmgr/lib/dcmgr/cli/host.rb
@@ -96,7 +96,7 @@ __END
       ds = HostNode.dataset
       table = [['UUID', 'Node ID', 'Hypervisor', 'Architecture', 'Usage', 'Status', 'Scheduling']]
       ds.each { |r|
-        table << [r.canonical_uuid, r.node_id, r.hypervisor, r.arch, "#{r.usage_percent}%", r.status, r.enabled]
+        table << [r.canonical_uuid, r.node_id, r.hypervisor, r.arch, "#{r.usage_percent}%", r.status, r.scheduling_enabled]
       }
       shell.print_table(table)
     end


### PR DESCRIPTION
`vdc-manage host show` results error:

```
$ /opt/axsh/wakame-vdc/dcmgr/bin/vdc-manage host show
ERROR: undefined method `enabled' for #<Dcmgr::Models::HostNode:0x007fdcbf866b60> (/opt/axsh/wakame-vdc/dcmgr/lib/dcmgr/cli/host.rb:99:in `block in show')
```
