### PR TITLE
Fixed OpenVZ which broke in the last merge

### DIFF
--- a/dcmgr/lib/dcmgr/drivers/hypervisor/linux_hypervisor/linux_container/openvz.rb
+++ b/dcmgr/lib/dcmgr/drivers/hypervisor/linux_hypervisor/linux_container/openvz.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-require File.dirname(__FILE__) + '/openvz_config.rb'
+require Dcmgr::DCMGR_ROOT + '/lib/dcmgr/drivers/openvz_config.rb'
 
 module Dcmgr
   module Drivers

--- a/dcmgr/lib/dcmgr/drivers/local_store/linux_local_store/openvz_local_store.rb
+++ b/dcmgr/lib/dcmgr/drivers/local_store/linux_local_store/openvz_local_store.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-require File.dirname(__FILE__) + '/openvz_config.rb'
+require Dcmgr::DCMGR_ROOT + '/lib/dcmgr/drivers/openvz_config.rb'
 
 module Dcmgr
   module Drivers


### PR DESCRIPTION
https://github.com/axsh/wakame-vdc/pull/456 introduced an API crash for OpenVZ instances. Interesting that the CI didn't catch this.
