### PR TITLE
Check if first-boot file exists for windows instances.

### DIFF
--- a/dcmgr/lib/dcmgr/drivers/hypervisor/linux_hypervisor/kvm.rb
+++ b/dcmgr/lib/dcmgr/drivers/hypervisor/linux_hypervisor/kvm.rb
@@ -147,7 +147,13 @@ module Dcmgr
 
         # We delete this file so Windows will not regenerate the administrator
         # password on reboot
-        File.delete(File.expand_path("#{mount_point}/meta-data/first-boot"))
+        first_boot_file = File.expand_path("#{mount_point}/meta-data/first-boot")
+        if File.exists?(first_boot_file)
+          File.delete(first_boot_file)
+        else
+          logger.warn "Unable to delete the first boot file on metadata drive. " +
+                      "File not found: #{first_boot_file}"
+        end
 
         umount_metadata_drive(hc, mount_point)
 


### PR DESCRIPTION
Wakame-vdc uses a file called `first-boot` on the metadata drive to tell Windows instances that this is the first time they're booted and thus they need to generate a new password.

To avoid crashing when the file doesn't exist, we first do a check to make sure it's there.
