### PR TITLE
Changed the default backup storage to match the installation guide

### DIFF
--- a/dcmgr/config/dcmgr.conf.example
+++ b/dcmgr/config/dcmgr.conf.example
@@ -49,7 +49,7 @@ cassandra_cf 'events'
 # collector_dcell_node_uri '127.0.0.1:9099'
 
 service_type("std", "StdServiceType") {
-  backup_storage_id 'bkst-demo2'
+  backup_storage_id 'bkst-local'
 
   #
   # Scheduling Algorithms


### PR DESCRIPTION
This should be merged at the same time as https://github.com/axsh/vmapp-vdc-1box/pull/13
