### PR TITLE
natbox agent fails that configuration parameters in hva.conf are referenced.

### DIFF
--- a/dcmgr/lib/dcmgr/configurations/hva.rb
+++ b/dcmgr/lib/dcmgr/configurations/hva.rb
@@ -2,6 +2,7 @@
 
 require "dcmgr/configurations/features"
 require "fuguta"
+require "dcmgr/edge_networking/openflow/ovs_ofctl"
 
 module Dcmgr
   module Configurations
@@ -174,6 +175,17 @@ module Dcmgr
           conf = Fuguta::Configuration::ConfigurationMethods.find_configuration_class(c).new(self.instance_variable_get(:@subject)).parse_dsl(&blk)
           @config[:hypervisor_driver][c] = conf
         end
+
+        # backward compatibility
+        def ovs_ofctl_path(v)
+          @config[:ovs_ofctl].config[:ovs_ofctl_path] = v
+        end
+        alias_method :ovs_ofctl_path=, :ovs_ofctl_path
+
+        def verbose_openflow(v)
+          @config[:ovs_ofctl].config[:verbose_openflow] = v
+        end
+        alias_method :verbose_openflow=, :verbose_openflow
       end
 
       on_initialize_hook do
@@ -184,6 +196,7 @@ module Dcmgr
         @config[:metadata] = Metadata.new(self)
         @config[:windows] = Windows.new(self)
         @config[:hypervisor_driver] = {}
+        @config[:ovs_ofctl] = EdgeNetworking::OpenFlow::OvsOfctl::Configuration.new(self)
       end
 
       param :vm_data_dir
@@ -192,7 +205,6 @@ module Dcmgr
       param :hv_ifindex, :default=>2
       param :bridge_novlan, :default=>0
       param :verbose_netfilter, :default=>false
-      param :verbose_openflow, :default=>false
       param :verbose_netfilter_cache, :default=>false
       param :packet_drop_log, :default => false
       param :debug_iptables, :default=>false
@@ -212,8 +224,6 @@ module Dcmgr
       param :brctl_path, :default => '/usr/sbin/brctl'
       param :vsctl_path, :default => '/usr/bin/ovs-vsctl'
       param :ovs_run_dir, :default=>'/usr/var/run/openvswitch'
-      # Path for ovs-ofctl
-      param :ovs_ofctl_path, :default => '/usr/bin/ovs-ofctl'
       # Trema base directory
       param :trema_dir, :default=>'/home/demo/trema'
       param :trema_tmp, :default=> proc {

--- a/dcmgr/lib/dcmgr/configurations/natbox.rb
+++ b/dcmgr/lib/dcmgr/configurations/natbox.rb
@@ -2,6 +2,7 @@
 
 require "dcmgr/configurations/features"
 require 'fuguta'
+require "dcmgr/edge_networking/openflow/ovs_ofctl"
 
 module Dcmgr
 
@@ -42,10 +43,19 @@ module Dcmgr
           conf = DcNetwork.new(name)
           @config[:inside_dc_network] = conf.parse_dsl(&blk)
         end
+
+        # backward compatiblility
+        def ovs_ofctl_path(v)
+          @config[:ovs_ofctl].config[:ovs_ofctl_path] = v
+        end
+        alias_method :ovs_ofctl_path=, :ovs_ofctl_path
+
+        def verbose_openflow(v)
+          @config[:ovs_ofctl].config[:verbose_openflow] = v
+        end
+        alias_method :verbose_openflow=, :verbose_openflow
       end
 
-      param :ovs_ofctl_path, :default => "/usr/bin/ovs-ofctl"
-      param :verbose_openflow, :default => false
       param :ovs_flow_table, :default => 0
       param :ovs_flow_priority, :default => 100
 
@@ -55,6 +65,10 @@ module Dcmgr
         end
       end
 
+      def after_initialize
+        super
+        @config[:ovs_ofctl] = EdgeNetworking::OpenFlow::OvsOfctl::Configuration.new(self)
+      end
     end
 
   end

--- a/dcmgr/lib/dcmgr/edge_networking/openflow/controller.rb
+++ b/dcmgr/lib/dcmgr/edge_networking/openflow/controller.rb
@@ -22,7 +22,7 @@ module Dcmgr
 
         def initialize service_openflow
           @service_openflow = service_openflow
-          @default_ofctl = OvsOfctl.new
+          @default_ofctl = OvsOfctl.new(Dcmgr::Configurations.hva.ovs_ofctl)
 
           @switches = {}
         end

--- a/dcmgr/lib/dcmgr/edge_networking/openflow/ovs_ofctl.rb
+++ b/dcmgr/lib/dcmgr/edge_networking/openflow/ovs_ofctl.rb
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+require "fuguta"
+
 module Dcmgr
   module EdgeNetworking
     module OpenFlow
@@ -11,13 +13,21 @@ module Dcmgr
         attr_accessor :verbose
         attr_accessor :switch_name
 
-        def initialize
-          # TODO: Make ovs_vsctl use a real config option.
-          @ovs_ofctl = Dcmgr::Configurations.hva.ovs_ofctl_path
-          @ovs_vsctl = Dcmgr::Configurations.hva.ovs_ofctl_path.dup
-          @ovs_vsctl[/ovs-ofctl/] = 'ovs-vsctl'
+        class Configuration < Fuguta::Configuration
+          param :ovs_ofctl_path, :default => "/usr/bin/ovs-ofctl"
+          param :ovs_vsctl_path, :default => "/usr/bin/ovs-vsctl"
+          param :verbose_openflow, :default => false
+        end
 
-          @verbose = Dcmgr::Configurations.hva.verbose_openflow
+        def initialize(conf)
+          if !conf.is_a?(Configuration)
+            raise ArgumentError, "#{Configuration} type is expected but #{conf.class}."
+          end
+          @conf = conf
+          @ovs_ofctl = conf.ovs_ofctl_path
+          @ovs_vsctl = conf.ovs_vsctl_path
+
+          @verbose = conf.verbose_openflow
         end
 
         def get_bridge_name datapath_id

--- a/dcmgr/lib/dcmgr/node_modules/service_natbox.rb
+++ b/dcmgr/lib/dcmgr/node_modules/service_natbox.rb
@@ -72,7 +72,7 @@ module Dcmgr::NodeModules
     private
     def ovs_ofctl
       return @ovs_ofctl if @ovs_ofctl
-      @ovs_ofctl = Dcmgr::EdgeNetworking::OpenFlow::OvsOfctl.new.tap do |ovs_ofctl|
+      @ovs_ofctl = Dcmgr::EdgeNetworking::OpenFlow::OvsOfctl.new(natbox_conf.ovs_ofctl).tap do |ovs_ofctl|
         ovs_ofctl.switch_name = natbox_conf.outside_dc_network.bridge
       end
     end


### PR DESCRIPTION
A utility class for ovs command line has been breaking natbox since the class expected hva.conf structure.

EdgeNetworking::OpenFlow::OvsOfctl class is being used by two agents, hva and natbox. The class assumes some ovs_* conf parameters and Dcmgr::Configration.hva is hard coded in the class.
It breaks when the class is used from the natbox agent because it holds configuration object under Dcmgr::Configration.natbox.

I changed OvsOfctl to have independent configuration class. OvsOfctl accepts its configuration class instance  at initializing time. The user takes responsibility to set parameters to the configuration class.