### PR TITLE
rpm: remove ovs dependencies from hva.

### DIFF
--- a/rpmbuild/SPECS/wakame-vdc.spec
+++ b/rpmbuild/SPECS/wakame-vdc.spec
@@ -184,10 +184,6 @@ Requires: iscsi-initiator-utils scsi-target-utils
 Requires: ebtables iptables ethtool vconfig iproute
 Requires: bridge-utils
 Requires: dracut-kernel
-Requires: kmod-openvswitch >= 1.6.1
-Requires: kmod-openvswitch <  1.6.2
-Requires: openvswitch      >= 1.6.1
-Requires: openvswitch      <  1.6.2
 Requires: kpartx
 Requires: libcgroup
 Requires: tunctl


### PR DESCRIPTION
ancient OVS packages, openvswitch-1.6.1,  no longer be installed with hva. 