### PR TITLE
Fix ARP broadcast from host

### DIFF
--- a/dcmgr/lib/dcmgr/edge_networking/network_modes/security_group.rb
+++ b/dcmgr/lib/dcmgr/edge_networking/network_modes/security_group.rb
@@ -29,9 +29,7 @@ module Dcmgr::EdgeNetworking::NetworkModes
       tasks << DropIpSpoofing.new(vnic[:address],enable_logging,"D arp sp #{vnic[:uuid]}: ")
       tasks << DropMacSpoofing.new(clean_mac(vnic[:mac_addr]),enable_logging,"D ip sp #{vnic[:uuid]}: ")
       tasks << AcceptGARPFromGateway.new(network[:ipv4_gw],enable_logging,"A garp from_gw #{vnic[:uuid]}: ") unless network[:ipv4_gw].nil?
-      host_addrs.each {|host_addr|
-        tasks << AcceptArpBroadcast.new(host_addr,enable_logging,"A arp bc #{vnic[:uuid]}: ")
-      }
+      tasks << AcceptArpBroadcast.new(enable_logging,"A arp bc #{vnic[:uuid]}: ")
 
       # General ip layer tasks
       tasks << AcceptIcmpRelatedEstablished.new

--- a/dcmgr/lib/dcmgr/edge_networking/tasks/accept_arp_broadcast.rb
+++ b/dcmgr/lib/dcmgr/edge_networking/tasks/accept_arp_broadcast.rb
@@ -8,12 +8,14 @@ module Dcmgr
         include Dcmgr::EdgeNetworking::Netfilter
         attr_accessor :hva_ip
 
-        def initialize(hva_ip,enable_logging = false,log_prefix = nil)
+        def initialize(enable_logging = false, log_prefix = nil)
           super()
-          self.hva_ip = hva_ip
+
+          rule = "-p ARP --arp-mac-dst 00:00:00:00:00:00 --dst ff:ff:ff:ff:ff:ff" +
+                 " #{EbtablesRule.log_arp(log_prefix) if enable_logging} -j ACCEPT"
 
           # Allow broadcast from the host
-          self.rules << EbtablesRule.new(:filter,:output,:arp,:outgoing,"--protocol arp --arp-opcode Request --arp-ip-src=#{self.hva_ip} #{EbtablesRule.log_arp(log_prefix) if enable_logging} -j ACCEPT")
+          self.rules << EbtablesRule.new(:filter, :output, :arp, :outgoing, rule)
         end
       end
 


### PR DESCRIPTION
The ebtables rule to accept ARP broadcast from host was relying on Isono to provide the correct IP address. It seems Isono can't be trusted to consistently do this so I refactored the rule to check for the broadcast mac address instead.