### PR TITLE
Maintenance vmapp

### DIFF
--- a/vmapp/backup_storage/image.ini
+++ b/vmapp/backup_storage/image.ini
@@ -7,7 +7,7 @@ swapsize      = 0
 
 hypervisor    = kvm
 distro-name   = centos
-distro-ver    = 6.3
+distro-ver    = 6.6
 arch          = x86_64
 sshd-passauth = no
 fstab-type    = label

--- a/vmapp/build.sh.d/wakame-init.sh
+++ b/vmapp/build.sh.d/wakame-init.sh
@@ -28,37 +28,38 @@ function install_wakame_init() {
   [[ -d "${chroot_dir}" ]] || { echo "[ERROR] directory not found: ${chroot_dir} (${BASH_SOURCE[0]##*/}:${LINENO})" >&2; return 1; }
 
   case "${metadata_type}" in
-  md)
-    prevent_interfaces_booting ${chroot_dir} eth*
-    ;;
-  ms|mcd)
-    ;;
-  *)
-    echo "[ERROR] unknown metadata_type:${metadata_type} ${BASH_SOURCE[0]##*/}:${LINENO})" >&2; return 1;
-    ;;
+    md)
+      prevent_interfaces_booting ${chroot_dir} eth*
+      ;;
+    ms|mcd)
+      ;;
+    *)
+      echo "[ERROR] unknown metadata_type:${metadata_type} ${BASH_SOURCE[0]##*/}:${LINENO})" >&2; return 1;
+      ;;
   esac
+
   local wakame_init_path
   case "${distro}" in
-  centos|rhel)
-    rsync -a $(cd ${BASH_SOURCE[0]%/*} && pwd)/../../rpmbuild/wakame-vdc.repo ${chroot_dir}/etc/yum.repos.d/wakame-vdc.repo
-    run_in_target ${chroot_dir} yum install -y wakame-init
-    ;;
-  ubuntu|debian)
-    wakame_init_path=${wakame_init_ubuntu_path}
+    centos|rhel)
+      rsync -a $(cd ${BASH_SOURCE[0]%/*} && pwd)/../../rpmbuild/wakame-vdc.repo ${chroot_dir}/etc/yum.repos.d/wakame-vdc.repo
+      run_in_target ${chroot_dir} yum install -y wakame-init
+      ;;
+    ubuntu|debian)
+      wakame_init_path=${wakame_init_ubuntu_path}
 
-    printf "[DEBUG] Installing wakame-init script\n"
-    cat <<-EOS >> ${chroot_dir}/etc/rc.local
+      printf "[DEBUG] Installing wakame-init script\n"
+      cat <<-EOS >> ${chroot_dir}/etc/rc.local
 	/etc/wakame-init ${metadata_type}
 	EOS
-    cat ${chroot_dir}/etc/rc.local
+      cat ${chroot_dir}/etc/rc.local
 
-    rsync -a ${wakame_init_path} ${chroot_dir}/etc/wakame-init
-    chmod 755 ${chroot_dir}/etc/wakame-init
-    chown 0:0 ${chroot_dir}/etc/wakame-init
-    ;;
-  *)
-    echo "[ERROR] not supported distro:${distro} ${BASH_SOURCE[0]##*/}:${LINENO})" >&2; return 1;
-    ;;
+      rsync -a ${wakame_init_path} ${chroot_dir}/etc/wakame-init
+      chmod 755 ${chroot_dir}/etc/wakame-init
+      chown 0:0 ${chroot_dir}/etc/wakame-init
+      ;;
+    *)
+      echo "[ERROR] not supported distro:${distro} ${BASH_SOURCE[0]##*/}:${LINENO})" >&2; return 1;
+      ;;
   esac
 }
 

--- a/vmapp/build.sh.d/wakame-init.sh
+++ b/vmapp/build.sh.d/wakame-init.sh
@@ -40,23 +40,8 @@ function install_wakame_init() {
   local wakame_init_path
   case "${distro}" in
   centos|rhel)
-    # TODO: use "yum install -y wakame-init"
-
-    wakame_init_path=${wakame_init_rhel_path}
-    rsync -a ${wakame_init_path} ${chroot_dir}/etc/wakame-init
-    chmod 755 ${chroot_dir}/etc/wakame-init
-    chown 0:0 ${chroot_dir}/etc/wakame-init
-
-    rsync -a $(cd ${BASH_SOURCE[0]%/*} && pwd)/../../wakame-init/rhel/6/default/wakame-init ${chroot_dir}/etc/default/wakame-init
-    chmod 644 ${chroot_dir}/etc/default/wakame-init
-    chown 0:0 ${chroot_dir}/etc/default/wakame-init
-
-    rsync -a $(cd ${BASH_SOURCE[0]%/*} && pwd)/../../wakame-init/rhel/6/init.d/wakame-init  ${chroot_dir}/etc/init.d/wakame-init
-    chmod 755 ${chroot_dir}/etc/init.d/wakame-init
-    chown 0:0 ${chroot_dir}/etc/init.d/wakame-init
-
-    run_in_target ${chroot_dir} chkconfig --add wakame-init
-    run_in_target ${chroot_dir} chkconfig       wakame-init on
+    rsync -a $(cd ${BASH_SOURCE[0]%/*} && pwd)/../../rpmbuild/wakame-vdc.repo ${chroot_dir}/etc/yum.repos.d/wakame-vdc.repo
+    run_in_target ${chroot_dir} yum install -y wakame-init
     ;;
   ubuntu|debian)
     wakame_init_path=${wakame_init_ubuntu_path}

--- a/vmapp/build.sh.d/wakame-init.sh
+++ b/vmapp/build.sh.d/wakame-init.sh
@@ -37,14 +37,13 @@ function install_wakame_init() {
       ;;
   esac
 
-  local wakame_init_path
   case "${distro}" in
     centos|rhel)
       rsync -a $(cd ${BASH_SOURCE[0]%/*} && pwd)/../../rpmbuild/wakame-vdc.repo ${chroot_dir}/etc/yum.repos.d/wakame-vdc.repo
       run_in_target ${chroot_dir} yum install -y wakame-init
       ;;
     ubuntu|debian)
-      wakame_init_path=${wakame_init_ubuntu_path}
+      local wakame_init_path=${wakame_init_ubuntu_path}
 
       printf "[DEBUG] Installing wakame-init script\n"
       cat <<-EOS >> ${chroot_dir}/etc/rc.local

--- a/vmapp/build.sh.d/wakame-init.sh
+++ b/vmapp/build.sh.d/wakame-init.sh
@@ -55,7 +55,7 @@ function install_wakame_init() {
 	EOS
   cat ${chroot_dir}/etc/rc.local
 
-  rsync -a ${wakame_init_rhel_path} ${chroot_dir}/etc/wakame-init
+  rsync -a ${wakame_init_path} ${chroot_dir}/etc/wakame-init
   chmod 755 ${chroot_dir}/etc/wakame-init
   chown 0:0 ${chroot_dir}/etc/wakame-init
 }

--- a/vmapp/build.sh.d/wakame-init.sh
+++ b/vmapp/build.sh.d/wakame-init.sh
@@ -19,7 +19,6 @@
 . $(cd ${BASH_SOURCE[0]%/*} && pwd)/../functions/distro.sh
 
 ##
-declare wakame_init_rhel_path=$(cd ${BASH_SOURCE[0]%/*} && pwd)/../../wakame-init/rhel/6/wakame-init
 declare wakame_init_ubuntu_path=$(cd ${BASH_SOURCE[0]%/*} && pwd)/../../wakame-init/ubuntu/10.04/wakame-init
 
 ##

--- a/vmapp/cassandra/image.ini
+++ b/vmapp/cassandra/image.ini
@@ -7,7 +7,7 @@ swapsize      = 0
 
 hypervisor    = kvm
 distro-name   = centos
-distro-ver    = 6.4
+distro-ver    = 6.6
 arch          = x86_64
 sshd-passauth = yes
 fstab-type    = label

--- a/vmapp/centos6/image.ini
+++ b/vmapp/centos6/image.ini
@@ -8,7 +8,7 @@ swapsize      = 0
 hypervisor    = kvm, lxc, openvz
 distro-name   = centos
 distro-ver    = 6.6
-arch          = x86_64, i686
+arch          = x86_64;, i686
 sshd-passauth = no
 fstab-type    = label
 

--- a/vmapp/centos6/image.ini
+++ b/vmapp/centos6/image.ini
@@ -14,4 +14,4 @@ fstab-type    = label
 
 [wakame-vdc]
 
-metadata-type = md, ms, mcd
+metadata-type = md, ms;, mcd

--- a/vmapp/centos6/image.ini
+++ b/vmapp/centos6/image.ini
@@ -1,13 +1,13 @@
 [vmbuilder]
 
-name          = centos-6.4
+name          = centos-6.6
 
 rootsize      = 4096
 swapsize      = 0
 
 hypervisor    = kvm, lxc, openvz
 distro-name   = centos
-distro-ver    = 6.4
+distro-ver    = 6.6
 arch          = x86_64, i686
 sshd-passauth = no
 fstab-type    = label

--- a/vmapp/functions/builder.sh
+++ b/vmapp/functions/builder.sh
@@ -58,6 +58,8 @@ VDC_HYPERVISOR=${vm_hypervisor} \
    --keepcache     ${vm_keepcache:-0} \
    --fstab-type    ${vm_fstab_type} \
    --sshd-passauth ${vm_sshd_passauth} \
+   --gssapi-auth   no \
+   --use-dns       no \
    --devel-user    wakame-vdc \
    --devel-pass    wakame-vdc \
    --execscript    $(pwd)/execscript.sh \

--- a/vmapp/functions/builder.sh
+++ b/vmapp/functions/builder.sh
@@ -58,8 +58,8 @@ VDC_HYPERVISOR=${vm_hypervisor} \
    --keepcache     ${vm_keepcache:-0} \
    --fstab-type    ${vm_fstab_type} \
    --sshd-passauth ${vm_sshd_passauth} \
-   --gssapi-auth   no \
-   --use-dns       no \
+   --sshd-gssapi-auth no \
+   --sshd-use-dns     no \
    --devel-user    wakame-vdc \
    --devel-pass    wakame-vdc \
    --execscript    $(pwd)/execscript.sh \

--- a/vmapp/functions/builder.sh
+++ b/vmapp/functions/builder.sh
@@ -58,6 +58,8 @@ VDC_HYPERVISOR=${vm_hypervisor} \
    --keepcache     ${vm_keepcache:-0} \
    --fstab-type    ${vm_fstab_type} \
    --sshd-passauth ${vm_sshd_passauth} \
+   --devel-user    wakame-vdc \
+   --devel-pass    wakame-vdc \
    --execscript    $(pwd)/execscript.sh \
    $([[ -f "$(pwd)/copy.txt" ]] && echo \
    --copy          $(pwd)/copy.txt

--- a/vmapp/lbnode/image.ini
+++ b/vmapp/lbnode/image.ini
@@ -7,7 +7,7 @@ swapsize      = 0
 
 hypervisor    = kvm, lxc, openvz
 distro-name   = centos
-distro-ver    = 6.4
+distro-ver    = 6.6
 arch          = x86_64, i686
 sshd-passauth = no
 fstab-type    = label

--- a/vmapp/lbnode/image.ini
+++ b/vmapp/lbnode/image.ini
@@ -8,7 +8,7 @@ swapsize      = 0
 hypervisor    = kvm, lxc, openvz
 distro-name   = centos
 distro-ver    = 6.6
-arch          = x86_64, i686
+arch          = x86_64;, i686
 sshd-passauth = no
 fstab-type    = label
 

--- a/vmapp/lbnode/image.ini
+++ b/vmapp/lbnode/image.ini
@@ -2,7 +2,7 @@
 
 name = lbnode
 
-rootsize      = 1024
+rootsize      = 2048
 swapsize      = 0
 
 hypervisor    = kvm, lxc, openvz

--- a/vmapp/load_balancer/image.ini
+++ b/vmapp/load_balancer/image.ini
@@ -7,7 +7,7 @@ swapsize      = 0
 
 hypervisor    = kvm, lxc, openvz
 distro-name   = centos
-distro-ver    = 6.4
+distro-ver    = 6.6
 arch          = x86_64, i686
 sshd-passauth = no
 fstab-type    = label

--- a/vmapp/load_balancer/image.ini
+++ b/vmapp/load_balancer/image.ini
@@ -8,7 +8,7 @@ swapsize      = 0
 hypervisor    = kvm, lxc, openvz
 distro-name   = centos
 distro-ver    = 6.6
-arch          = x86_64, i686
+arch          = x86_64;, i686
 sshd-passauth = no
 fstab-type    = label
 

--- a/vmapp/load_balancer/image.ini
+++ b/vmapp/load_balancer/image.ini
@@ -1,6 +1,6 @@
 [vmbuilder]
 
-name = lb-centos6-stud
+name = lb-centos6.6-stud
 
 rootsize      = 2048
 swapsize      = 0

--- a/vmapp/load_balancer/image.ini
+++ b/vmapp/load_balancer/image.ini
@@ -2,7 +2,7 @@
 
 name = lb-centos6-stud
 
-rootsize      = 1024
+rootsize      = 2048
 swapsize      = 0
 
 hypervisor    = kvm, lxc, openvz

--- a/vmapp/natbox/image.ini
+++ b/vmapp/natbox/image.ini
@@ -7,7 +7,7 @@ swapsize      = 0
 
 hypervisor    = kvm
 distro-name   = centos
-distro-ver    = 6.3
+distro-ver    = 6.6
 arch          = x86_64
 sshd-passauth = no
 fstab-type    = label

--- a/vmapp/selenium2-box/image.ini
+++ b/vmapp/selenium2-box/image.ini
@@ -7,7 +7,7 @@ swapsize      = 1024
 
 hypervisor    = kvm; , lxc, openvz
 distro-name   = centos
-distro-ver    = 6.4
+distro-ver    = 6.6
 arch          = x86_64; , i686
 sshd-passauth = yes
 fstab-type    = label

--- a/vmapp/selenium2-box/image.ini
+++ b/vmapp/selenium2-box/image.ini
@@ -8,10 +8,10 @@ swapsize      = 1024
 hypervisor    = kvm; , lxc, openvz
 distro-name   = centos
 distro-ver    = 6.6
-arch          = x86_64; ;, i686
+arch          = x86_64; , i686
 sshd-passauth = yes
 fstab-type    = label
 
 [wakame-vdc]
 
-metadata-type = md; , ms;, mcd
+metadata-type = md; , ms, mcd

--- a/vmapp/selenium2-box/image.ini
+++ b/vmapp/selenium2-box/image.ini
@@ -14,4 +14,4 @@ fstab-type    = label
 
 [wakame-vdc]
 
-metadata-type = md; , ms, mcd
+metadata-type = md; , ms;, mcd

--- a/vmapp/selenium2-box/image.ini
+++ b/vmapp/selenium2-box/image.ini
@@ -8,7 +8,7 @@ swapsize      = 1024
 hypervisor    = kvm; , lxc, openvz
 distro-name   = centos
 distro-ver    = 6.6
-arch          = x86_64; , i686
+arch          = x86_64; ;, i686
 sshd-passauth = yes
 fstab-type    = label
 

--- a/vmapp/test/unit/build/wakame-init/t.install_wakame_init.sh
+++ b/vmapp/test/unit/build/wakame-init/t.install_wakame_init.sh
@@ -29,6 +29,7 @@ EOS
   function chmod() { echo chmod $*; }
   function chown() { echo chown $*; }
   function prevent_interfaces_booting() { echo prevent_interfaces_booting $*; }
+  function chroot() { echo chroot $*; }
 }
 
 function tearDown() {

--- a/vmapp/vanilla/image.ini
+++ b/vmapp/vanilla/image.ini
@@ -7,7 +7,7 @@ swapsize      = 0
 
 hypervisor    = kvm, lxc, openvz
 distro-name   = centos
-distro-ver    = 6.4
+distro-ver    = 6.6
 arch          = x86_64, i686
 sshd-passauth = yes
 fstab-type    = label

--- a/vmapp/vanilla/image.ini
+++ b/vmapp/vanilla/image.ini
@@ -14,4 +14,4 @@ fstab-type    = label
 
 [wakame-vdc]
 
-metadata-type = md, ms, mcd
+metadata-type = md, ms;, mcd

--- a/vmapp/vanilla/image.ini
+++ b/vmapp/vanilla/image.ini
@@ -8,7 +8,7 @@ swapsize      = 0
 hypervisor    = kvm, lxc, openvz
 distro-name   = centos
 distro-ver    = 6.6
-arch          = x86_64, i686
+arch          = x86_64;, i686
 sshd-passauth = yes
 fstab-type    = label
 

--- a/vmapp/zabbix/image.ini
+++ b/vmapp/zabbix/image.ini
@@ -7,7 +7,7 @@ swapsize      = 0
 
 hypervisor    = kvm
 distro-name   = centos
-distro-ver    = 6.3
+distro-ver    = 6.6
 arch          = x86_64
 sshd-passauth = no
 fstab-type    = label


### PR DESCRIPTION
CI passed with new vmimages.

### Maintenance

1. update `centos` to 6.6
2. remove `i686` from default arch target
   + because of `i686` no longer used

### New features

1. use `wakame-vdc rpm` instead of simple file copy
   + increase disk size for `wakame-vdc` rpm installation because yum`s metadata uses disk.
2. configure `sshd_conf` not to use dns for quick logging-in 
   + `GSSAPIAuthentication no`
   + `UseDNS no`

### For developer

1. add `wakame-vdc` unix user as maintenance account to all vm images for investigation and debugging
   + user: `wakame-vdc`
   + pass: `wakame-vdc`
   + `sudo` privilege
   + (`PasswordAuthentication: no`)
