### PR TITLE
show list of network_vifs.

### DIFF
--- a/dcmgr/lib/dcmgr/endpoints/12.03/network_vifs.rb
+++ b/dcmgr/lib/dcmgr/endpoints/12.03/network_vifs.rb
@@ -5,6 +5,18 @@ require 'dcmgr/endpoints/12.03/responses/network_vif_monitor'
 
 Dcmgr::Endpoints::V1203::CoreAPI.namespace '/network_vifs' do
 
+  # Show list of network_vifs
+  get do
+    ds = M::NetworkVif
+    if params[:account_id]
+      ds = ds.filter(:account_id=>params[:account_id])
+    end
+
+    collection_respond_with(ds) do |paging_ds|
+      R::NetworkVifCollection.new(paging_ds).generate
+    end
+  end
+
   get '/:vif_id' do
     # description "Retrieve details about a vif"
     # params id, string, required


### PR DESCRIPTION
### Feature

This change will provide list of network_vifs.

### Background

for bash/zsh completion support for `mussel.sh`.

When registering/unregistering `network_vif` to a `load_balancer`, mussel.sh expects network_vif candidate using network_vif list.
But current implementation does not provide network_vif list.

### How it works

```
$ mussel.sh network_vif index
```

Sample output:

> ```
> $ mussel.sh network_vif index  | head -50
> ---
> - :total: 18
>   :start: 0
>   :limit: 250
>   :results:
>   - :id: vif-cze58riq
>     :uuid: vif-cze58riq
>     :ipv4_address: 10.1.0.10
>     :nat_ipv4_address:
>     :network_id: nw-demo8
>     :instance_id: i-9c5q6wa5
>     :security_groups: []
>     :mac_addr: 52:54:00:ff:61:33
>     :network_monitors: []
>     :ip_leases:
>     - :ipv4: 10.1.0.10
>       :network_id: nw-demo8
>       :ip_handle:
>   - :id: vif-uuzbsk75
>     :uuid: vif-uuzbsk75
>     :ipv4_address: 10.0.2.102
>     :nat_ipv4_address:
>     :network_id: nw-demo1
>     :instance_id: i-9c5q6wa5
>     :security_groups:
>     - sg-dbzjq4sq
>     :mac_addr: 52:54:00:eb:cd:2d
>     :network_monitors: []
>     :ip_leases:
>     - :ipv4: 10.0.2.102
>       :network_id: nw-demo1
>       :ip_handle:
>   - :id: vif-2ifofi7t
>     :uuid: vif-2ifofi7t
>     :ipv4_address: 10.0.2.101
>     :nat_ipv4_address:
>     :network_id: nw-demo1
>     :instance_id: i-63vi9vhj
>     :security_groups:
>     - sg-nhrd602s
>     :mac_addr: 52:54:00:41:26:c6
>     :network_monitors: []
>     :ip_leases:
>     - :ipv4: 10.0.2.101
>       :network_id: nw-demo1
>       :ip_handle:
>   - :id: vif-389nvf7i
>     :uuid: vif-389nvf7i
>     :ipv4_address: 10.0.2.100
>     :nat_ipv4_address:
```
