### PR TITLE
enable to set "state" option.

### DIFF
--- a/client/mussel/v12.03.d/volume.sh
+++ b/client/mussel/v12.03.d/volume.sh
@@ -5,6 +5,14 @@
 
 . ${BASH_SOURCE[0]%/*}/base.sh
 
+task_index() {
+  # --state=(alive|alive_with_deleted|available|attached|deleted)
+  if [[ -n "${state}" ]]; then
+    xquery="state=${state}"
+  fi
+  cmd_index $*
+}
+
 task_backup() {
   local namespace=$1 cmd=$2 uuid=$3
   [[ -n "${namespace}" ]] || { echo "[ERROR] 'namespace' is empty (${BASH_SOURCE[0]##*/}:${LINENO})" >&2; return 1; }


### PR DESCRIPTION
### Feature

This change will provide volume state option.

```
$ mussel.sh volume index --state [ alive | alive_with_deleted | attached | available | deleted ]
```

### Background

for bash/zsh completion support for `mussel.sh`.

When attaching/detaching `volume` to a `instance`, mussel.sh expects volume candidate using volume list.
But current implementation can not specify state option for volume. (current implementation ignores state option)

### How to use

```
$ mussel.sh volume index --state alive
$ mussel.sh volume index --state alive_with_deleted
$ mussel.sh volume index --state attached
$ mussel.sh volume index --state available
$ mussel.sh volume index --state deleted
```
