### PR TITLE
enable to set "--is-public" option."

### DIFF
--- a/client/mussel/v12.03.d/image.sh
+++ b/client/mussel/v12.03.d/image.sh
@@ -4,3 +4,11 @@
 #
 
 . ${BASH_SOURCE[0]%/*}/base.sh
+
+task_index() {
+  # --is-public=(true|false|0|1)
+  if [[ -n "${is_public}" ]]; then
+      xquery="is_public=${is_public}"
+  fi
+  cmd_index $*
+}


### PR DESCRIPTION
### Feature

This change will provide image `--is-public` option.

```
$ mussel.sh image index --is-public [ true | false | 0 | 1 ]
```

### Background

for bash/zsh completion support for `mussel.sh`.

When launching `instance`, mussel.sh expects image candidate using image list.
But current implementation can not specify `--is-public` option for image. (current implementation ignores `--is-public` option)

### How to use

```
$ mussel.sh image index --is-public true
$ mussel.sh image index --is-public false
$ mussel.sh image index --is-public 0
$ mussel.sh image index --is-public 1
```
