### PR TITLE
Feature mussel image index opts

### DIFF
--- a/client/mussel/v12.03.d/image.sh
+++ b/client/mussel/v12.03.d/image.sh
@@ -10,5 +10,9 @@ task_index() {
   if [[ -n "${is_public}" ]]; then
       xquery="is_public=${is_public}"
   fi
+  # --service-type=(std|lb)
+  if [[ -n "${service_type}" ]]; then
+    xquery="${xquery}\&service_type=${service_type}"
+  fi
   cmd_index $*
 }

--- a/client/mussel/v12.03.d/image.sh
+++ b/client/mussel/v12.03.d/image.sh
@@ -14,5 +14,9 @@ task_index() {
   if [[ -n "${service_type}" ]]; then
     xquery="${xquery}\&service_type=${service_type}"
   fi
+  # --state=(alive|alive_with_deleted|available|deleted)
+  if [[ -n "${state}" ]]; then
+    xquery="${xquery}\&state=${state}"
+  fi
   cmd_index $*
 }

--- a/client/mussel/v12.03.d/image.sh
+++ b/client/mussel/v12.03.d/image.sh
@@ -4,3 +4,11 @@
 #
 
 . ${BASH_SOURCE[0]%/*}/base.sh
+
+task_index() {
+  # --is-public=(true|false|0|1)
+  if [[ -n "${is_public}" ]]; then
+      xquery="is_public=${is_public}"
+  fi
+  cmd_index $*
+}

--- a/client/mussel/v12.03.d/image.sh
+++ b/client/mussel/v12.03.d/image.sh
@@ -8,7 +8,7 @@
 task_index() {
   # --is-public=(true|false|0|1)
   if [[ -n "${is_public}" ]]; then
-      xquery="is_public=${is_public}"
+    xquery="is_public=${is_public}"
   fi
   # --service-type=(std|lb)
   if [[ -n "${service_type}" ]]; then


### PR DESCRIPTION
### Feature

This change will provide image `--state` option and `--service-type` option.

```
$ mussel.sh image index --state [ alive | alive_with_deleted | available | deleted ]
$ mussel.sh image index --service-type [ std | lb ]
```

### Background

for bash/zsh completion support for `mussel.sh`.

### How to use

```
$ mussel.sh image index --state alive
$ mussel.sh image index --state alive_with_deleted
$ mussel.sh image index --state available
$ mussel.sh image index --state deleted
```

```
$ mussel.sh image index --service-type std
$ mussel.sh image index --service-type lb
```
