### PR TITLE
add "update" to instance.

### DIFF
--- a/client/mussel/test/component/v12.03/t.instance.sh
+++ b/client/mussel/test/component/v12.03/t.instance.sh
@@ -360,6 +360,23 @@ function test_instance_backup_volume() {
                
 }
 
+### update
+
+function test_instance_update() {
+  local cmd=update
+
+  local display_name=shunit2
+  local ssh_key_id=ssh-demo
+
+  local params="
+    display_name=${display_name}
+    ssh_key_id=${ssh_key_id}
+  "
+
+  assertEquals "$(cli_wrapper ${namespace} ${cmd} ${uuid})" \
+               "curl -X PUT $(urlencode_data ${params}) $(base_uri)/${namespace}s/${uuid}.$(suffix)"
+}
+
 ## shunit2
 
 . ${shunit2_file}

--- a/client/mussel/test/unit/v12.03/t.instance.sh
+++ b/client/mussel/test/unit/v12.03/t.instance.sh
@@ -25,7 +25,7 @@ function setUp() {
 function test_instance_help_stderr_to_stdout_success() {
   extract_args ${namespace} help
   res=$(run_cmd  ${MUSSEL_ARGS} 2>&1)
-  assertEquals "$0 ${namespace} [help|backup|backup_volume|create|destroy|index|move|poweroff|poweron|reboot|show|show_volumes|xcreate]" "${res}"
+  assertEquals "$0 ${namespace} [help|backup|backup_volume|create|destroy|index|move|poweroff|poweron|reboot|show|show_volumes|update|xcreate]" "${res}"
 }
 
 ### index
@@ -127,6 +127,20 @@ function test_instance_poweron_no_uuid() {
 
 function test_instance_poweron_uuid() {
   extract_args ${namespace} poweron i-xxx
+  run_cmd ${MUSSEL_ARGS}
+  assertEquals 0 $?
+}
+
+### update
+
+function test_instance_update_no_uuid() {
+  extract_args ${namespace} update
+  run_cmd ${MUSSEL_ARGS} 2>/dev/null
+  assertNotEquals 0 $?
+}
+
+function test_instance_update_uuid() {
+  extract_args ${namespace} update i-xxx
   run_cmd ${MUSSEL_ARGS}
   assertEquals 0 $?
 }

--- a/client/mussel/v12.03.d/instance.sh
+++ b/client/mussel/v12.03.d/instance.sh
@@ -109,3 +109,16 @@ task_move() {
    ) \
    $(base_uri)/${namespace}s/${uuid}/${cmd}.$(suffix)
 }
+
+task_update() {
+  local namespace=$1 cmd=$2 uuid=$3
+  [[ -n "${namespace}" ]] || { echo "[ERROR] 'namespace' is empty (${BASH_SOURCE[0]##*/}:${LINENO})" >&2; return 1; }
+  [[ -n "${cmd}"       ]] || { echo "[ERROR] 'cmd' is empty (${BASH_SOURCE[0]##*/}:${LINENO})" >&2; return 1; }
+  [[ -n "${uuid}"      ]] || { echo "[ERROR] 'uuid' is empty (${BASH_SOURCE[0]##*/}:${LINENO})" >&2; return 1; }
+
+  call_api -X PUT $(urlencode_data \
+    $(add_param display_name        string) \
+    $(add_param ssh_key_id          string) \
+   ) \
+   $(base_uri)/${namespace}s/${uuid}.$(suffix)
+}


### PR DESCRIPTION
### Feature

This change will provide updating instance params.

### How to use

```
$ mussel.sh instance update i-xxx --display-name foo
$ mussel.sh instance update i-xxx --ssh-key-id ssh-xxx
$ mussel.sh instance update i-xxx --display-name foo --ssh-key-id ssh-xxx
```

sample output:

> ```
> $ mussel.sh instance update i-uxfjkucx --ssh-key-id ssh-f18g6pe3 --display-name ssh-f18g6pe3
> ---
> :id: i-uxfjkucx
> :account_id: a-shpoolxx
> :host_node: hn-1box64
> :cpu_cores: 1
> :memory_size: 256
> :arch: x86_64
> :image_id: wmi-haproxy1d64
> :created_at: 2015-04-15 12:05:17.000000000 Z
> :updated_at: 2015-04-15 12:39:34.863434452 Z
> :terminated_at:
> :deleted_at:
> :state: running
> :status: online
> :ssh_key_pair:
>   :uuid: ssh-f18g6pe3
>   :display_name: ''
> :volume:
> - :vol_id: vol-t57bv5pb
>   :state: attached
> :vif:
> - :vif_id: vif-r7xfn72a
>   :network_id: nw-demo1
>   :ipv4:
>     :address: 10.0.2.100
>     :nat_address:
>   :security_groups:
>   - sg-aq9xw03r
> - :vif_id: vif-y2cguuxp
>   :network_id: nw-demo8
>   :ipv4:
>     :address: 10.1.0.10
>     :nat_address:
>   :security_groups: []
> :hostname: uxfjkucx
> :ha_enabled: 0
> :hypervisor: openvz
> :display_name: ssh-f18g6pe3
> :service_type: std
> :monitoring:
>   :enabled: false
>   :mail_address: []
>   :items: {}
> :labels:
> - :resource_uuid: i-uxfjkucx
>   :name: monitoring.enabled
>   :value_type: 1
>   :value: 'false'
>   :created_at: 2015-04-15 12:05:17.000000000 Z
>   :updated_at: 2015-04-15 12:05:17.000000000 Z
> :boot_volume_id: vol-t57bv5pb
> :encrypted_password:
> ```

#### pre-setup

Create a ssh keypair.

```
$ ssh-keygen -N "" -f mykeypair
$ mussel.sh ssh_key_pair create --public-key mykeypair.pub
# => ssh-xxx
```

Create an instance.

```
$ mussel.sh instance create \
 --hypervisor openvz \
 --cpu-cores 1 \
 --image-id wmi-lbnode1d64 \
 --memory-size 256 \
 --ssh-key-id <*ssh-xxx*>
# => i-xxx
```
