### PR TITLE
add halted to lb state list.

### DIFF
--- a/dcmgr/lib/dcmgr/endpoints/12.03/load_balancers.rb
+++ b/dcmgr/lib/dcmgr/endpoints/12.03/load_balancers.rb
@@ -6,7 +6,7 @@ require 'amqp'
 
 Dcmgr::Endpoints::V1203::CoreAPI.namespace '/load_balancers' do
   LOAD_BALANCER_META_STATE = ['alive', 'alive_with_deleted'].freeze
-  LOAD_BALANCER_STATE=['running', 'terminated'].freeze
+  LOAD_BALANCER_STATE=['running', 'halted', 'terminated'].freeze
   LOAD_BALANCER_STATE_ALL=(LOAD_BALANCER_STATE + LOAD_BALANCER_META_STATE).freeze
 
   register Sinatra::InternalRequest


### PR DESCRIPTION
### Problem

The API does not support load_balancer.state specified filter with `halted`.

https://github.com/axsh/wakame-vdc/blob/master/dcmgr/lib/dcmgr/endpoints/12.03/load_balancers.rb#L9

```
  LOAD_BALANCER_STATE=['running', 'terminated'].freeze
```

https://github.com/axsh/wakame-vdc/blob/master/dcmgr/lib/dcmgr/endpoints/12.03/load_balancers.rb#L28-L29

```
           when *LOAD_BALANCER_STATE
             ds.by_state(params[:state])
```

### Purpose to fix

+ In order to list `poweron` target.

#### Steps to reprocude:

1. Create 1 load_balancer with mussel
2. Power off one of created load_balancer with mussel
3. API Call with load_balancer.state

```
$ mussel.sh load_balancer create --balance-algorithm leastconn --engine haproxy --instance-port 80 --instance-protocol http --max-connection 1000 --port 80 --protocol http
# => lb-A
```

```
$ mussel.sh load_balancer poweroff <*lb-A*>
```

```
$ mussel.sh load_balancer index --state alive
# => 1 lb
$ mussel.sh load_balancer index --state running
# => 0 lb 
$ mussel.sh load_balancer index --state halted
# => 1 lb
$ mussel.sh instance index --state terminated
# => 0 lb
```

### Solution

Add `halted` to `LOAD_BALANCER_STATE` like following:

```
  LOAD_BALANCER_STATE=['running', 'halted', 'terminated'].freeze
```
