### PR TITLE
add proper new-line.

### DIFF
--- a/dcmgr/lib/dcmgr/drivers/hypervisor/linux_hypervisor/kvm.rb
+++ b/dcmgr/lib/dcmgr/drivers/hypervisor/linux_hypervisor/kvm.rb
@@ -204,14 +204,14 @@ RUN_SH
 
         hc.inst[:vif].each do |vif|
           if vif[:ipv4] and vif[:ipv4][:network]
-            sh("/sbin/ip link set %s up" % [vif_uuid(vif)])
+            sh("/sbin/ip link set %s up\n" % [vif_uuid(vif)])
             bridge = bridge_if_name(vif[:ipv4][:network][:dc_network])
 
             attach_vif_cmd = attach_vif_to_bridge(bridge, vif)
             sh(attach_vif_cmd)
 
-            run_sh += ("/sbin/ip link set %s up" % [vif_uuid(vif)])
-            run_sh += (attach_vif_cmd)
+            run_sh += ("/sbin/ip link set %s up\n" % [vif_uuid(vif)])
+            run_sh += ("%s\n" % attach_vif_cmd)
           end
         end
 


### PR DESCRIPTION
the detail is #533

### How to test/confirm

Create an ssh keypair.


```
$ ssh-keygen -N "" -f mykeypair
$ mussel ssh_key_pair create --public-key mykeypair.pub
```

Create a vifs.txt.

```
$ cat <<'EOS' > vifs.txt
{
"eth0":{"network":"nw-demo1"},
"eth1":{"network":"nw-demo1"}
}
EOS
```

Create a instance.

```
$ mussel instance create --cpu-cores 1 --hypervisor kvm --image-id wmi-centos1d64 --memory-size 256 --ssh-key-id ssh-iyz3lxbt --vifs vifs.txt
```

Show the run.sh.

```
$ cat /var/lib/wakame-vdc/instances/i-0hmm8yxq/run.sh
#!/bin/bash
/usr/libexec/qemu-kvm -m 256 -smp 1 -name vdc-i-0hmm8yxq -pidfile /var/lib/wakame-vdc/instances/i-0hmm8yxq/kvm.pid -daemonize -monitor telnet:127.0.0.1:29258,server,nowait -no-kvm-pit-reinjection -vnc 127.0.0.1:26534 -serial telnet:127.0.0.1:31900,server,nowait -drive file=/var/lib/wakame-vdc/instances/i-0hmm8yxq/vol-wpk07zg2,id=vol-wpk07zg2-drive,if=none,serial=vol-wpk07zg2,cache=none,aio=native -device virtio-blk-pci,id=vol-wpk07zg2,drive=vol-wpk07zg2-drive,bootindex=0,bus=pci.0,addr=0x4 -drive file=/var/lib/wakame-vdc/instances/i-0hmm8yxq/metadata.img,id=metadata-drive,if=none,serial=metadata,cache=none,aio=native -device virtio-blk-pci,id=metadata,drive=metadata-drive,bus=pci.0,addr=0x5 -net nic,vlan=0,macaddr=52:54:00:11:63:00,model=virtio,addr=10 -net tap,vlan=0,ifname=vif-9yhtmmrq,script=no,downscript=no -net nic,vlan=1,macaddr=52:54:00:8f:e4:31,model=virtio,addr=11 -net tap,vlan=1,ifname=vif-xtoaymuc,script=no,downscript=no
/sbin/ip link set vif-9yhtmmrq up
/usr/sbin/brctl addif br0 vif-9yhtmmrq
/sbin/ip link set vif-xtoaymuc up
/usr/sbin/brctl addif br0 vif-xtoaymuc
```
