### PR TITLE
Feature mussel completion

### DIFF
--- a/client/mussel/completion/README.md
+++ b/client/mussel/completion/README.md
@@ -1,4 +1,4 @@
-# bash/zsh completion support for mussel.sh
+# bash/zsh completion support for mussel
 
 ## Installation
 

--- a/client/mussel/completion/README.md
+++ b/client/mussel/completion/README.md
@@ -1,0 +1,10 @@
+# bash/zsh completion support for mussel.sh
+
+## Installation
+
+1. Copy this file to somewhere (e.g. `~/.mussel-completion.bash`).
+2. Add the following line to your `.bashrc/.zshrc`:
+
+```
+source ~/.mussel-completion.bash
+```

--- a/client/mussel/completion/mussel-completion.bash
+++ b/client/mussel/completion/mussel-completion.bash
@@ -5,7 +5,7 @@
 #  egrep, awk
 #
 # description:
-#  bash/zsh completion support for mussel.sh
+#  bash/zsh completion support for mussel
 #
 # usage:
 #   1) Copy this file to somewhere (e.g. ~/.mussel-completion.bash).
@@ -23,7 +23,7 @@ function hash_value() {
   egrep -w -- "- :${key}:" </dev/stdin | awk '{ if (NF == 2) {print $2} else if (NF == 3) {print $3} }'
 }
 
-_mussel.sh() {
+_mussel() {
   local cur=${COMP_WORDS[COMP_CWORD]}
   local prev=${COMP_WORDS[COMP_CWORD-1]}
   local offset=${#COMP_WORDS[@]}
@@ -88,22 +88,22 @@ _mussel.sh() {
       show)
         # "--is-public" for image.index.
         # this options will be ignored in other namespace.
-        COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index --is-public true | hash_value id)" -- ${cur}))
+        COMPREPLY=($(compgen -W "$(mussel ${COMP_WORDS[1]} index --is-public true | hash_value id)" -- ${cur}))
         ;;
       update | destroy)
-        COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index --state alive   | hash_value id)" -- ${cur}))
+        COMPREPLY=($(compgen -W "$(mussel ${COMP_WORDS[1]} index --state alive   | hash_value id)" -- ${cur}))
         ;;
       poweroff)
-        COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index --state running | hash_value id)" -- ${cur}))
+        COMPREPLY=($(compgen -W "$(mussel ${COMP_WORDS[1]} index --state running | hash_value id)" -- ${cur}))
         ;;
       poweron)
-        COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index --state halted  | hash_value id)" -- ${cur}))
+        COMPREPLY=($(compgen -W "$(mussel ${COMP_WORDS[1]} index --state halted  | hash_value id)" -- ${cur}))
         ;;
       backup)
-        COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index --state alive   | hash_value id)" -- ${cur}))
+        COMPREPLY=($(compgen -W "$(mussel ${COMP_WORDS[1]} index --state alive   | hash_value id)" -- ${cur}))
         ;;
       register | unregister)
-        COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index --state running | hash_value id)" -- ${cur}))
+        COMPREPLY=($(compgen -W "$(mussel ${COMP_WORDS[1]} index --state running | hash_value id)" -- ${cur}))
         ;;
       *)
         needmore=yes
@@ -163,13 +163,13 @@ _mussel.sh() {
               COMPREPLY=($(compgen -W "1 2 4" -- ${cur}))
               ;;
             --image-id)
-              COMPREPLY=($(compgen -W "$(mussel.sh image index --is-public true | hash_value id)" -- ${cur}))
+              COMPREPLY=($(compgen -W "$(mussel image index --is-public true | hash_value id)" -- ${cur}))
               ;;
             --memory-size)
               COMPREPLY=($(compgen -W "256 512" -- ${cur}))
               ;;
             --ssh-key-id)
-              COMPREPLY=($(compgen -W "$(mussel.sh ssh_key_pair index | hash_value id)" -- ${cur}))
+              COMPREPLY=($(compgen -W "$(mussel ssh_key_pair index | hash_value id)" -- ${cur}))
               ;;
             --vifs)
               COMPREPLY=($(compgen -f ${cur}))
@@ -222,7 +222,7 @@ _mussel.sh() {
         register | unregister)
           case "${prev}" in
             --vifs)
-              COMPREPLY=($(compgen -W "$(mussel.sh instance index | hash_value vif_id)" -- ${cur}))
+              COMPREPLY=($(compgen -W "$(mussel instance index | hash_value vif_id)" -- ${cur}))
               ;;
             *)
               COMPREPLY=($(compgen -W "--vifs" -- ${cur}))
@@ -284,5 +284,4 @@ _mussel.sh() {
   esac
 }
 
-complete -F _mussel.sh mussel.sh
-complete -F _mussel.sh mussel
+complete -F _mussel mussel

--- a/client/mussel/completion/mussel-completion.bash
+++ b/client/mussel/completion/mussel-completion.bash
@@ -52,44 +52,43 @@ _mussel.sh() {
     case "${prev}" in
       backup_object | host_node | image | network | network_vif | volume )
         COMPREPLY=($(compgen -W "${tasks_ro}" -- ${cur}))
-        return 0
         ;;
       instance)
         COMPREPLY=($(compgen -W "${tasks_rw} poweroff poweron backup" -- ${cur}))
-        return 0
         ;;
       load_balancer)
         COMPREPLY=($(compgen -W "${tasks_rw} register unregister" -- ${cur}))
-        return 0
         ;;
       ssh_key_pair | security_group)
         COMPREPLY=($(compgen -W "${tasks_rw}" -- ${cur}))
-        return 0
         ;;
     esac
+    return 0
   elif [[ ${offset} == 4 ]]; then
+    local needmore=
     case "${prev}" in
       show)
         COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index | hash_value id)" -- ${cur}))
-        return 0
         ;;
       update | destroy)
         COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index --state alive | hash_value id)" -- ${cur}))
-        return 0
         ;;
       poweroff)
         COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index --state running | hash_value id)" -- ${cur}))
-        return 0
         ;;
       poweron | backup)
         COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index --state alive | hash_value id)" -- ${cur}))
-        return 0
         ;;
       register | unregister)
         COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index --state running | hash_value id)" -- ${cur}))
-        return 0
+        ;;
+      *)
+        needmore=yes
         ;;
     esac
+    if [[ -z "${needmore}" ]]; then
+      return 0
+    fi
   fi
 
   local namespace=${COMP_WORDS[1]}

--- a/client/mussel/completion/mussel-completion.bash
+++ b/client/mussel/completion/mussel-completion.bash
@@ -33,10 +33,12 @@ _mussel.sh() {
   elif [[ ${offset} == 2 ]]; then
     local namespaces="
       backup_object
+      host_node
       image
       instance
       load_balancer
       network
+      network_vif
       security_group
       ssh_key_pair
     "
@@ -47,12 +49,8 @@ _mussel.sh() {
     local tasks_rw="${tasks_ro} create update destroy"
 
     case "${prev}" in
-      image | network | backup_object)
+      backup_object | host_node | image | network | network_vif)
         COMPREPLY=($(compgen -W "${tasks_ro}" -- ${cur}))
-        return 0
-        ;;
-      ssh_key_pair | security_group)
-        COMPREPLY=($(compgen -W "${tasks_rw}" -- ${cur}))
         return 0
         ;;
       instance)
@@ -61,6 +59,10 @@ _mussel.sh() {
         ;;
       load_balancer)
         COMPREPLY=($(compgen -W "${tasks_rw} register unregister" -- ${cur}))
+        return 0
+        ;;
+      ssh_key_pair | security_group)
+        COMPREPLY=($(compgen -W "${tasks_rw}" -- ${cur}))
         return 0
         ;;
     esac
@@ -93,40 +95,6 @@ _mussel.sh() {
   local task=${COMP_WORDS[2]}
 
   case "${namespace}" in
-    ssh_key_pair)
-      case "${task}" in
-        index)
-          ;;
-        create)
-          case "${prev}" in
-            --public-key)
-              COMPREPLY=($(compgen -f ${cur}))
-              ;;
-            *)
-              COMPREPLY=($(compgen -W "--public-key" -- ${cur}))
-              ;;
-          esac
-	  ;;
-      esac
-      ;;
-
-    security_group)
-      case "${task}" in
-        index)
-          ;;
-        create)
-          case "${prev}" in
-            --rule)
-              COMPREPLY=($(compgen -f ${cur}))
-              ;;
-            *)
-              COMPREPLY=($(compgen -W "--rule" -- ${cur}))
-              ;;
-          esac
-          ;;
-      esac
-      ;;
-
     instance)
       case "${task}" in
         index)
@@ -216,6 +184,41 @@ _mussel.sh() {
           ;;
       esac
       ;;
+
+    security_group)
+      case "${task}" in
+        index)
+          ;;
+        create)
+          case "${prev}" in
+            --rule)
+              COMPREPLY=($(compgen -f ${cur}))
+              ;;
+            *)
+              COMPREPLY=($(compgen -W "--rule" -- ${cur}))
+              ;;
+          esac
+          ;;
+      esac
+      ;;
+
+    ssh_key_pair)
+      case "${task}" in
+        index)
+          ;;
+        create)
+          case "${prev}" in
+            --public-key)
+              COMPREPLY=($(compgen -f ${cur}))
+              ;;
+            *)
+              COMPREPLY=($(compgen -W "--public-key" -- ${cur}))
+              ;;
+          esac
+          ;;
+      esac
+      ;;
+
   esac
 }
 

--- a/client/mussel/completion/mussel-completion.bash
+++ b/client/mussel/completion/mussel-completion.bash
@@ -71,19 +71,19 @@ _mussel.sh() {
         return 0
         ;;
       update | destroy)
-        COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index | hash_value id)" -- ${cur}))
+        COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index --state alive | hash_value id)" -- ${cur}))
         return 0
         ;;
       poweroff)
-        COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index | hash_value id)" -- ${cur}))
+        COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index --state running | hash_value id)" -- ${cur}))
         return 0
         ;;
       poweron | backup)
-        COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index | hash_value id)" -- ${cur}))
+        COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index --state alive | hash_value id)" -- ${cur}))
         return 0
         ;;
       register | unregister)
-        COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index | hash_value id)" -- ${cur}))
+        COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index --state running | hash_value id)" -- ${cur}))
         return 0
         ;;
     esac

--- a/client/mussel/completion/mussel-completion.bash
+++ b/client/mussel/completion/mussel-completion.bash
@@ -1,0 +1,188 @@
+# -*-Shell-script-*#
+#
+# requires:
+#  bash
+#  egrep, awk
+#
+# description:
+#  bash-completion for mussel.sh
+#
+
+function hash_value() {
+  local key=$1 line
+
+  #
+  # NF=2) ":id: i-xxx"
+  # NF=3) "- :vif_id: vif-qqjr0ial"
+  #
+  egrep -w ":${key}:" </dev/stdin | awk '{ if (NF == 2) {print $2} else if (NF == 3) {print $3} }'
+}
+
+_mussel.sh() {
+  local cur=${COMP_WORDS[COMP_CWORD]}
+  local prev=${COMP_WORDS[COMP_CWORD-1]}
+  local offset=${#COMP_WORDS[@]}
+
+  if [[ ${offset} == 1 ]]; then
+    return 0
+  elif [[ ${offset} == 2 ]]; then
+    local namespaces="
+      backup_object
+      image
+      instance
+      load_balancer
+      network
+      security_group
+      ssh_key_pair
+    "
+    COMPREPLY=($(compgen -W "${namespaces}" ${cur}))
+    return 0
+  elif [[ ${offset} == 3 ]]; then
+    local tasks_ro="index show"
+    local tasks_rw="${tasks_ro} create update destroy"
+
+    case "${prev}" in
+      image | network | backup_object)
+        COMPREPLY=($(compgen -W "${tasks_ro}" -- ${cur}))
+        return 0
+        ;;
+      ssh_key_pair | security_group)
+        COMPREPLY=($(compgen -W "${tasks_rw}" -- ${cur}))
+        return 0
+        ;;
+      instance)
+        COMPREPLY=($(compgen -W "${tasks_rw} poweroff poweron backup" -- ${cur}))
+        return 0
+        ;;
+      load_balancer)
+        COMPREPLY=($(compgen -W "${tasks_rw} register unregister" -- ${cur}))
+        return 0
+        ;;
+    esac
+  elif [[ ${offset} == 4 ]]; then
+    case "${prev}" in
+      index)
+        return 0
+        ;;
+      show | update | destroy)
+        COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index | hash_value id)" -- ${cur}))
+        return 0
+        ;;
+      poweroff | poweron | backup)
+        COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index | hash_value id)" -- ${cur}))
+        return 0
+        ;;
+      register | unregister)
+        COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index | hash_value id)" -- ${cur}))
+        return 0
+        ;;
+    esac
+  fi
+
+  local namespace=${COMP_WORDS[1]}
+  local task=${COMP_WORDS[2]}
+
+    case "${namespace}" in
+      ssh_key_pair)
+        case "${task}" in
+          create)
+            case "${prev}" in
+              --public-key)
+                COMPREPLY=($(compgen -f ${cur}))
+                ;;
+              *)
+                COMPREPLY=($(compgen -W "--public-key" -- ${cur}))
+                ;;
+            esac
+          ;;
+        esac
+        ;;
+
+      security_group)
+        case "${task}" in
+          create)
+            case "${prev}" in
+              --rule)
+                COMPREPLY=($(compgen -f ${cur}))
+                ;;
+              *)
+                COMPREPLY=($(compgen -W "--rule" -- ${cur}))
+                ;;
+            esac
+          ;;
+        esac
+        ;;
+
+      instance)
+        case "${task}" in
+          create)
+            case "${prev}" in
+              --hypervisor)
+                COMPREPLY=($(compgen -W "openvz lxc kvm" -- ${cur}))
+                ;;
+              --cpu-cores)
+                COMPREPLY=($(compgen -W "1 2 4" -- ${cur}))
+                ;;
+              --image-id)
+                COMPREPLY=($(compgen -W "$(mussel.sh image index | hash_value uuid)" -- ${cur}))
+                ;;
+              --memory-size)
+                COMPREPLY=($(compgen -W "256 512" -- ${cur}))
+                ;;
+              --ssh-key-id)
+                COMPREPLY=($(compgen -W "$(mussel.sh ssh_key_pair index | hash_value uuid)" -- ${cur}))
+                ;;
+              --vifs)
+                COMPREPLY=($(compgen -f ${cur}))
+                ;;
+              *)
+                COMPREPLY=($(compgen -W "--hypervisor --cpu-cores --image-id --memory-size --ssh-key-id --vifs" -- ${cur}))
+                ;;
+            esac 
+            ;;
+        esac
+        ;;
+
+      load_balancer)
+        case "${task}" in
+          create)
+            case "${prev}" in
+              --balance-algorithm)
+                COMPREPLY=($(compgen -W "leastconn" -- ${cur}))
+                ;;
+              --cookie)
+                COMPREPLY=($(compgen -W "haproxy" -- ${cur}))
+                ;;
+              --engine)
+                COMPREPLY=($(compgen -W "haproxy" -- ${cur}))
+                ;;
+              --port | --instance-port)
+                COMPREPLY=($(compgen -W "80 443" -- ${cur}))
+                ;;
+              --protocol | --instance-protocol)
+                COMPREPLY=($(compgen -W "http https tcp" -- ${cur}))
+                ;;
+              --max-connection)
+                COMPREPLY=($(compgen -W "1000" -- ${cur}))
+                ;;
+              *)
+                COMPREPLY=($(compgen -W "--balance-algorithm --engine --port --instance-port --protocol --instance-protocol --max-connection" -- ${cur}))
+                ;;
+            esac
+            ;;
+          register | unregister)
+            case "${prev}" in
+              --vifs)
+                COMPREPLY=($(compgen -W "$(mussel.sh instance index | hash_value vif_id)" -- ${cur}))
+                ;;
+              *)
+                COMPREPLY=($(compgen -W "--vifs" -- ${cur}))
+                ;;
+            esac
+            ;;
+        esac
+        ;;
+    esac
+}
+
+complete -F _mussel.sh mussel.sh

--- a/client/mussel/completion/mussel-completion.bash
+++ b/client/mussel/completion/mussel-completion.bash
@@ -66,14 +66,19 @@ _mussel.sh() {
     esac
   elif [[ ${offset} == 4 ]]; then
     case "${prev}" in
-      index)
-        return 0
-        ;;
-      show | update | destroy)
+      show)
         COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index | hash_value id)" -- ${cur}))
         return 0
         ;;
-      poweroff | poweron | backup)
+      update | destroy)
+        COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index | hash_value id)" -- ${cur}))
+        return 0
+        ;;
+      poweroff)
+        COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index | hash_value id)" -- ${cur}))
+        return 0
+        ;;
+      poweron | backup)
         COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index | hash_value id)" -- ${cur}))
         return 0
         ;;
@@ -90,7 +95,9 @@ _mussel.sh() {
   case "${namespace}" in
     ssh_key_pair)
       case "${task}" in
-    	  create)
+        index)
+          ;;
+        create)
           case "${prev}" in
             --public-key)
               COMPREPLY=($(compgen -f ${cur}))
@@ -99,12 +106,14 @@ _mussel.sh() {
               COMPREPLY=($(compgen -W "--public-key" -- ${cur}))
               ;;
           esac
-	      ;;
+	  ;;
       esac
       ;;
 
     security_group)
       case "${task}" in
+        index)
+          ;;
         create)
           case "${prev}" in
             --rule)
@@ -120,6 +129,16 @@ _mussel.sh() {
 
     instance)
       case "${task}" in
+        index)
+          case "${prev}" in
+            --state)
+              COMPREPLY=($(compgen -W "alive alive_with_terminated without_terminated running stopped terminated" -- ${cur}))
+              ;;
+            *)
+              COMPREPLY=($(compgen -W "--state" -- ${cur}))
+              ;;
+          esac
+          ;;
         create)
           case "${prev}" in
             --hypervisor)
@@ -150,6 +169,16 @@ _mussel.sh() {
 
     load_balancer)
       case "${task}" in
+        index)
+          case "${prev}" in
+            --state)
+              COMPREPLY=($(compgen -W "alive alive_with_deleted running terminated" -- ${cur}))
+              ;;
+            *)
+              COMPREPLY=($(compgen -W "--state" -- ${cur}))
+              ;;
+          esac
+          ;;
         create)
           case "${prev}" in
             --balance-algorithm)

--- a/client/mussel/completion/mussel-completion.bash
+++ b/client/mussel/completion/mussel-completion.bash
@@ -75,7 +75,7 @@ _mussel.sh() {
         COMPREPLY=($(compgen -W "${tasks_rw} poweroff poweron backup" -- ${cur}))
         ;;
       load_balancer)
-        COMPREPLY=($(compgen -W "${tasks_rw} register unregister" -- ${cur}))
+        COMPREPLY=($(compgen -W "${tasks_rw} poweroff poweron register unregister" -- ${cur}))
         ;;
       image | ssh_key_pair | security_group)
         COMPREPLY=($(compgen -W "${tasks_rw}" -- ${cur}))

--- a/client/mussel/completion/mussel-completion.bash
+++ b/client/mussel/completion/mussel-completion.bash
@@ -96,7 +96,10 @@ _mussel.sh() {
       poweroff)
         COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index --state running | hash_value id)" -- ${cur}))
         ;;
-      poweron | backup)
+      poweron)
+        COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index --state halted  | hash_value id)" -- ${cur}))
+        ;;
+      backup)
         COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index --state alive   | hash_value id)" -- ${cur}))
         ;;
       register | unregister)

--- a/client/mussel/completion/mussel-completion.bash
+++ b/client/mussel/completion/mussel-completion.bash
@@ -285,3 +285,4 @@ _mussel.sh() {
 }
 
 complete -F _mussel.sh mussel.sh
+complete -F _mussel.sh mussel

--- a/client/mussel/completion/mussel-completion.bash
+++ b/client/mussel/completion/mussel-completion.bash
@@ -184,7 +184,7 @@ _mussel.sh() {
         index)
           case "${prev}" in
             --state)
-              COMPREPLY=($(compgen -W "alive alive_with_deleted running terminated" -- ${cur}))
+              COMPREPLY=($(compgen -W "alive alive_with_deleted running halted terminated" -- ${cur}))
               ;;
             *)
               COMPREPLY=($(compgen -W "--state" -- ${cur}))

--- a/client/mussel/completion/mussel-completion.bash
+++ b/client/mussel/completion/mussel-completion.bash
@@ -144,7 +144,7 @@ _mussel.sh() {
               COMPREPLY=($(compgen -W "std lb" -- ${cur}))
               ;;
             --state)
-              COMPREPLY=($(compgen -W "alive alive_with_terminated without_terminated running stopped terminated" -- ${cur}))
+              COMPREPLY=($(compgen -W "alive alive_with_terminated without_terminated running stopped halted terminated" -- ${cur}))
               ;;
             *)
               COMPREPLY=($(compgen -W "--service-type --state" -- ${cur}))

--- a/client/mussel/completion/mussel-completion.bash
+++ b/client/mussel/completion/mussel-completion.bash
@@ -5,7 +5,12 @@
 #  egrep, awk
 #
 # description:
-#  bash-completion for mussel.sh
+#  bash/zsh completion support for mussel.sh
+#
+# usage:
+#   1) Copy this file to somewhere (e.g. ~/.mussel-completion.bash).
+#   2) Add the following line to your .bashrc/.zshrc:
+#       source ~/.git-completion.bash
 #
 
 function hash_value() {

--- a/client/mussel/completion/mussel-completion.bash
+++ b/client/mussel/completion/mussel-completion.bash
@@ -86,7 +86,9 @@ _mussel.sh() {
     local needmore=
     case "${prev}" in
       show)
-        COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index | hash_value id)" -- ${cur}))
+        # "--is-public" for image.index.
+        # this options will be ignored in other namespace.
+        COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index --is-public true | hash_value id)" -- ${cur}))
         ;;
       update | destroy)
         COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index --state alive   | hash_value id)" -- ${cur}))
@@ -155,7 +157,7 @@ _mussel.sh() {
               COMPREPLY=($(compgen -W "1 2 4" -- ${cur}))
               ;;
             --image-id)
-              COMPREPLY=($(compgen -W "$(mussel.sh image index | hash_value id)" -- ${cur}))
+              COMPREPLY=($(compgen -W "$(mussel.sh image index --is-public true | hash_value id)" -- ${cur}))
               ;;
             --memory-size)
               COMPREPLY=($(compgen -W "256 512" -- ${cur}))

--- a/client/mussel/completion/mussel-completion.bash
+++ b/client/mussel/completion/mussel-completion.bash
@@ -194,7 +194,7 @@ _mussel.sh() {
               COMPREPLY=($(compgen -W "80 443" -- ${cur}))
               ;;
             --protocol | --instance-protocol)
-              COMPREPLY=($(compgen -W "http https tcp" -- ${cur}))
+              COMPREPLY=($(compgen -W "http https tcp ssl" -- ${cur}))
               ;;
             --max-connection)
               COMPREPLY=($(compgen -W "1000" -- ${cur}))

--- a/client/mussel/completion/mussel-completion.bash
+++ b/client/mussel/completion/mussel-completion.bash
@@ -63,7 +63,6 @@ _mussel.sh() {
       | backup_storage \
       | dc_network \
       | host_node \
-      | image \
       | instance_monitoring \
       | network \
       | network_vif_monitor \
@@ -78,7 +77,7 @@ _mussel.sh() {
       load_balancer)
         COMPREPLY=($(compgen -W "${tasks_rw} register unregister" -- ${cur}))
         ;;
-      ssh_key_pair | security_group)
+      image | ssh_key_pair | security_group)
         COMPREPLY=($(compgen -W "${tasks_rw}" -- ${cur}))
         ;;
     esac
@@ -121,8 +120,14 @@ _mussel.sh() {
             --is-public)
               COMPREPLY=($(compgen -W "true false 0 1" -- ${cur}))
               ;;
+            --service-type)
+              COMPREPLY=($(compgen -W "std lb" -- ${cur}))
+              ;;
+            --state)
+              COMPREPLY=($(compgen -W "alive alive_with_deleted available deleted" -- ${cur}))
+              ;;
             *)
-              COMPREPLY=($(compgen -W "--is-public" -- ${cur}))
+              COMPREPLY=($(compgen -W "--is-public --service-type --state" -- ${cur}))
               ;;
           esac
           ;;

--- a/client/mussel/completion/mussel-completion.bash
+++ b/client/mussel/completion/mussel-completion.bash
@@ -140,11 +140,14 @@ _mussel.sh() {
       case "${task}" in
         index)
           case "${prev}" in
+            --service-type)
+              COMPREPLY=($(compgen -W "std lb" -- ${cur}))
+              ;;
             --state)
               COMPREPLY=($(compgen -W "alive alive_with_terminated without_terminated running stopped terminated" -- ${cur}))
               ;;
             *)
-              COMPREPLY=($(compgen -W "--state" -- ${cur}))
+              COMPREPLY=($(compgen -W "--service-type --state" -- ${cur}))
               ;;
           esac
           ;;

--- a/client/mussel/completion/mussel-completion.bash
+++ b/client/mussel/completion/mussel-completion.bash
@@ -71,13 +71,13 @@ _mussel.sh() {
         COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index | hash_value id)" -- ${cur}))
         ;;
       update | destroy)
-        COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index --state alive | hash_value id)" -- ${cur}))
+        COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index --state alive   | hash_value id)" -- ${cur}))
         ;;
       poweroff)
         COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index --state running | hash_value id)" -- ${cur}))
         ;;
       poweron | backup)
-        COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index --state alive | hash_value id)" -- ${cur}))
+        COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index --state alive   | hash_value id)" -- ${cur}))
         ;;
       register | unregister)
         COMPREPLY=($(compgen -W "$(mussel.sh ${COMP_WORDS[1]} index --state running | hash_value id)" -- ${cur}))

--- a/client/mussel/completion/mussel-completion.bash
+++ b/client/mussel/completion/mussel-completion.bash
@@ -114,6 +114,21 @@ _mussel.sh() {
   local task=${COMP_WORDS[2]}
 
   case "${namespace}" in
+    image)
+      case "${task}" in
+        index)
+          case "${prev}" in
+            --is-public)
+              COMPREPLY=($(compgen -W "true false 0 1" -- ${cur}))
+              ;;
+            *)
+              COMPREPLY=($(compgen -W "--is-public" -- ${cur}))
+              ;;
+          esac
+          ;;
+      esac
+      ;;
+
     instance)
       case "${task}" in
         index)

--- a/client/mussel/completion/mussel-completion.bash
+++ b/client/mussel/completion/mussel-completion.bash
@@ -9,7 +9,7 @@
 #
 
 function hash_value() {
-  local key=$1 line
+  local key=$1
 
   #
   # NF=2) ":id: i-xxx"

--- a/client/mussel/completion/mussel-completion.bash
+++ b/client/mussel/completion/mussel-completion.bash
@@ -182,7 +182,7 @@ _mussel.sh() {
         create)
           case "${prev}" in
             --balance-algorithm)
-              COMPREPLY=($(compgen -W "leastconn" -- ${cur}))
+              COMPREPLY=($(compgen -W "leastconn source" -- ${cur}))
               ;;
             --cookie)
               COMPREPLY=($(compgen -W "haproxy" -- ${cur}))

--- a/client/mussel/completion/mussel-completion.bash
+++ b/client/mussel/completion/mussel-completion.bash
@@ -222,7 +222,7 @@ _mussel() {
         register | unregister)
           case "${prev}" in
             --vifs)
-              COMPREPLY=($(compgen -W "$(mussel instance index | hash_value vif_id)" -- ${cur}))
+              COMPREPLY=($(compgen -W "$(mussel instance index --state alive | hash_value vif_id)" -- ${cur}))
               ;;
             *)
               COMPREPLY=($(compgen -W "--vifs" -- ${cur}))

--- a/client/mussel/completion/mussel-completion.bash
+++ b/client/mussel/completion/mussel-completion.bash
@@ -10,7 +10,7 @@
 # usage:
 #   1) Copy this file to somewhere (e.g. ~/.mussel-completion.bash).
 #   2) Add the following line to your .bashrc/.zshrc:
-#       source ~/.git-completion.bash
+#       source ~/.mussel-completion.bash
 #
 
 function hash_value() {

--- a/client/mussel/completion/mussel-completion.bash
+++ b/client/mussel/completion/mussel-completion.bash
@@ -82,107 +82,107 @@ _mussel.sh() {
   local namespace=${COMP_WORDS[1]}
   local task=${COMP_WORDS[2]}
 
-    case "${namespace}" in
-      ssh_key_pair)
-        case "${task}" in
-          create)
-            case "${prev}" in
-              --public-key)
-                COMPREPLY=($(compgen -f ${cur}))
-                ;;
-              *)
-                COMPREPLY=($(compgen -W "--public-key" -- ${cur}))
-                ;;
-            esac
+  case "${namespace}" in
+    ssh_key_pair)
+      case "${task}" in
+    	  create)
+          case "${prev}" in
+            --public-key)
+              COMPREPLY=($(compgen -f ${cur}))
+              ;;
+            *)
+              COMPREPLY=($(compgen -W "--public-key" -- ${cur}))
+              ;;
+          esac
+	      ;;
+      esac
+      ;;
+
+    security_group)
+      case "${task}" in
+        create)
+          case "${prev}" in
+            --rule)
+              COMPREPLY=($(compgen -f ${cur}))
+              ;;
+            *)
+              COMPREPLY=($(compgen -W "--rule" -- ${cur}))
+              ;;
+          esac
           ;;
-        esac
-        ;;
+      esac
+      ;;
 
-      security_group)
-        case "${task}" in
-          create)
-            case "${prev}" in
-              --rule)
-                COMPREPLY=($(compgen -f ${cur}))
-                ;;
-              *)
-                COMPREPLY=($(compgen -W "--rule" -- ${cur}))
-                ;;
-            esac
+    instance)
+      case "${task}" in
+        create)
+          case "${prev}" in
+            --hypervisor)
+              COMPREPLY=($(compgen -W "openvz lxc kvm" -- ${cur}))
+              ;;
+            --cpu-cores)
+              COMPREPLY=($(compgen -W "1 2 4" -- ${cur}))
+              ;;
+            --image-id)
+              COMPREPLY=($(compgen -W "$(mussel.sh image index | hash_value uuid)" -- ${cur}))
+              ;;
+            --memory-size)
+              COMPREPLY=($(compgen -W "256 512" -- ${cur}))
+              ;;
+            --ssh-key-id)
+              COMPREPLY=($(compgen -W "$(mussel.sh ssh_key_pair index | hash_value uuid)" -- ${cur}))
+              ;;
+            --vifs)
+              COMPREPLY=($(compgen -f ${cur}))
+              ;;
+            *)
+              COMPREPLY=($(compgen -W "--hypervisor --cpu-cores --image-id --memory-size --ssh-key-id --vifs" -- ${cur}))
+              ;;
+          esac
           ;;
-        esac
-        ;;
+      esac
+      ;;
 
-      instance)
-        case "${task}" in
-          create)
-            case "${prev}" in
-              --hypervisor)
-                COMPREPLY=($(compgen -W "openvz lxc kvm" -- ${cur}))
-                ;;
-              --cpu-cores)
-                COMPREPLY=($(compgen -W "1 2 4" -- ${cur}))
-                ;;
-              --image-id)
-                COMPREPLY=($(compgen -W "$(mussel.sh image index | hash_value uuid)" -- ${cur}))
-                ;;
-              --memory-size)
-                COMPREPLY=($(compgen -W "256 512" -- ${cur}))
-                ;;
-              --ssh-key-id)
-                COMPREPLY=($(compgen -W "$(mussel.sh ssh_key_pair index | hash_value uuid)" -- ${cur}))
-                ;;
-              --vifs)
-                COMPREPLY=($(compgen -f ${cur}))
-                ;;
-              *)
-                COMPREPLY=($(compgen -W "--hypervisor --cpu-cores --image-id --memory-size --ssh-key-id --vifs" -- ${cur}))
-                ;;
-            esac 
-            ;;
-        esac
-        ;;
-
-      load_balancer)
-        case "${task}" in
-          create)
-            case "${prev}" in
-              --balance-algorithm)
-                COMPREPLY=($(compgen -W "leastconn" -- ${cur}))
-                ;;
-              --cookie)
-                COMPREPLY=($(compgen -W "haproxy" -- ${cur}))
-                ;;
-              --engine)
-                COMPREPLY=($(compgen -W "haproxy" -- ${cur}))
-                ;;
-              --port | --instance-port)
-                COMPREPLY=($(compgen -W "80 443" -- ${cur}))
-                ;;
-              --protocol | --instance-protocol)
-                COMPREPLY=($(compgen -W "http https tcp" -- ${cur}))
-                ;;
-              --max-connection)
-                COMPREPLY=($(compgen -W "1000" -- ${cur}))
-                ;;
-              *)
-                COMPREPLY=($(compgen -W "--balance-algorithm --engine --port --instance-port --protocol --instance-protocol --max-connection" -- ${cur}))
-                ;;
-            esac
-            ;;
-          register | unregister)
-            case "${prev}" in
-              --vifs)
-                COMPREPLY=($(compgen -W "$(mussel.sh instance index | hash_value vif_id)" -- ${cur}))
-                ;;
-              *)
-                COMPREPLY=($(compgen -W "--vifs" -- ${cur}))
-                ;;
-            esac
-            ;;
-        esac
-        ;;
-    esac
+    load_balancer)
+      case "${task}" in
+        create)
+          case "${prev}" in
+            --balance-algorithm)
+              COMPREPLY=($(compgen -W "leastconn" -- ${cur}))
+              ;;
+            --cookie)
+              COMPREPLY=($(compgen -W "haproxy" -- ${cur}))
+              ;;
+            --engine)
+              COMPREPLY=($(compgen -W "haproxy" -- ${cur}))
+              ;;
+            --port | --instance-port)
+              COMPREPLY=($(compgen -W "80 443" -- ${cur}))
+              ;;
+            --protocol | --instance-protocol)
+              COMPREPLY=($(compgen -W "http https tcp" -- ${cur}))
+              ;;
+            --max-connection)
+              COMPREPLY=($(compgen -W "1000" -- ${cur}))
+              ;;
+            *)
+              COMPREPLY=($(compgen -W "--balance-algorithm --engine --port --instance-port --protocol --instance-protocol --max-connection" -- ${cur}))
+              ;;
+          esac
+          ;;
+        register | unregister)
+          case "${prev}" in
+            --vifs)
+              COMPREPLY=($(compgen -W "$(mussel.sh instance index | hash_value vif_id)" -- ${cur}))
+              ;;
+            *)
+              COMPREPLY=($(compgen -W "--vifs" -- ${cur}))
+              ;;
+          esac
+          ;;
+      esac
+      ;;
+  esac
 }
 
 complete -F _mussel.sh mussel.sh

--- a/client/mussel/completion/mussel-completion.bash
+++ b/client/mussel/completion/mussel-completion.bash
@@ -32,15 +32,23 @@ _mussel.sh() {
     return 0
   elif [[ ${offset} == 2 ]]; then
     local namespaces="
+      alarm
       backup_object
+      backup_storage
+      dc_network
       host_node
       image
+      instance_monitoring
       instance
       load_balancer
+      ip_handle
+      ip_pool
       network
+      network_vif_monitor
       network_vif
       security_group
       ssh_key_pair
+      storage_node
       volume
     "
     COMPREPLY=($(compgen -W "${namespaces}" ${cur}))
@@ -50,7 +58,18 @@ _mussel.sh() {
     local tasks_rw="${tasks_ro} create update destroy"
 
     case "${prev}" in
-      backup_object | host_node | image | network | network_vif | volume )
+      alarm \
+      | backup_object \
+      | backup_storage \
+      | dc_network \
+      | host_node \
+      | image \
+      | instance_monitoring \
+      | network \
+      | network_vif_monitor \
+      | network_vif \
+      | storage_node \
+      | volume )
         COMPREPLY=($(compgen -W "${tasks_ro}" -- ${cur}))
         ;;
       instance)

--- a/client/mussel/completion/mussel-completion.bash
+++ b/client/mussel/completion/mussel-completion.bash
@@ -20,7 +20,7 @@ function hash_value() {
   # NF=2) ":id: i-xxx"
   # NF=3) "- :vif_id: vif-qqjr0ial"
   #
-  egrep -w ":${key}:" </dev/stdin | awk '{ if (NF == 2) {print $2} else if (NF == 3) {print $3} }'
+  egrep -w -- "- :${key}:" </dev/stdin | awk '{ if (NF == 2) {print $2} else if (NF == 3) {print $3} }'
 }
 
 _mussel.sh() {
@@ -41,6 +41,7 @@ _mussel.sh() {
       network_vif
       security_group
       ssh_key_pair
+      volume
     "
     COMPREPLY=($(compgen -W "${namespaces}" ${cur}))
     return 0
@@ -49,7 +50,7 @@ _mussel.sh() {
     local tasks_rw="${tasks_ro} create update destroy"
 
     case "${prev}" in
-      backup_object | host_node | image | network | network_vif)
+      backup_object | host_node | image | network | network_vif | volume )
         COMPREPLY=($(compgen -W "${tasks_ro}" -- ${cur}))
         return 0
         ;;
@@ -116,13 +117,13 @@ _mussel.sh() {
               COMPREPLY=($(compgen -W "1 2 4" -- ${cur}))
               ;;
             --image-id)
-              COMPREPLY=($(compgen -W "$(mussel.sh image index | hash_value uuid)" -- ${cur}))
+              COMPREPLY=($(compgen -W "$(mussel.sh image index | hash_value id)" -- ${cur}))
               ;;
             --memory-size)
               COMPREPLY=($(compgen -W "256 512" -- ${cur}))
               ;;
             --ssh-key-id)
-              COMPREPLY=($(compgen -W "$(mussel.sh ssh_key_pair index | hash_value uuid)" -- ${cur}))
+              COMPREPLY=($(compgen -W "$(mussel.sh ssh_key_pair index | hash_value id)" -- ${cur}))
               ;;
             --vifs)
               COMPREPLY=($(compgen -f ${cur}))
@@ -213,6 +214,21 @@ _mussel.sh() {
               ;;
             *)
               COMPREPLY=($(compgen -W "--public-key" -- ${cur}))
+              ;;
+          esac
+          ;;
+      esac
+      ;;
+
+    volume)
+      case "${task}" in
+        index)
+          case "${prev}" in
+            --state)
+              COMPREPLY=($(compgen -W "alive alive_with_deleted available attached deleted" -- ${cur}))
+              ;;
+            *)
+              COMPREPLY=($(compgen -W "--state" -- ${cur}))
               ;;
           esac
           ;;


### PR DESCRIPTION
### Description

bash/zsh completion support for mussel.

### Usage

1. Copy this file to somewhere (e.g. `~/.mussel-completion.bash`).
2. Add the following line to your `.bashrc/.zshrc`:
`source ~/.mussel-completion.bash`
