### PR TITLE
Fix haproxy updater

### DIFF
--- a/vmapp/load_balancer/etc/init/haproxy_updater.conf
+++ b/vmapp/load_balancer/etc/init/haproxy_updater.conf
@@ -34,9 +34,9 @@ script
 
   INSTANCE_ID=`cat ${METADATA_DRIVE_MOUNTPOINT}/meta-data/instance-id`
 
-  [ -z "${AMQP_SERVER}" ] && { echo "AMQP_SERVER is empty." >&2; exit 1; }
-  [ -z "${AMQP_PORT}"   ] && { echo   "AMQP_PORT is empty." >&2; exit 1; }
-  [ -z "${INSTANCE_ID}" ] && { echo "INSTANCE_ID is empty." >&2; exit 1; }
+  [ -z "${AMQP_SERVER}" ] && { echo "AMQP_SERVER is empty." | logger; exit 1; }
+  [ -z "${AMQP_PORT}"   ] && { echo   "AMQP_PORT is empty." | logger; exit 1; }
+  [ -z "${INSTANCE_ID}" ] && { echo "INSTANCE_ID is empty." | logger; exit 1; }
 
   exec ${base_path}/amqptools/bin/amqpspawn \
    -f \

--- a/vmapp/load_balancer/etc/init/haproxy_updater.conf
+++ b/vmapp/load_balancer/etc/init/haproxy_updater.conf
@@ -30,13 +30,9 @@ script
     }
   fi
 
-  USERDATA=`cat ${METADATA_DRIVE_MOUNTPOINT}/user-data`
-  INSTANCE_ID=`cat ${METADATA_DRIVE_MOUNTPOINT}/meta-data/instance-id`
+  . ${METADATA_DRIVE_MOUNTPOINT}/user-data
 
-  for i in $USERDATA
-  do
-    eval $i
-  done
+  INSTANCE_ID=`cat ${METADATA_DRIVE_MOUNTPOINT}/meta-data/instance-id`
 
   [ -z "${AMQP_SERVER}" ] && { echo "AMQP_SERVER is empty." >&2; exit 1; }
   [ -z "${AMQP_PORT}"   ] && { echo   "AMQP_PORT is empty." >&2; exit 1; }

--- a/vmapp/load_balancer/etc/init/haproxy_updater.conf
+++ b/vmapp/load_balancer/etc/init/haproxy_updater.conf
@@ -25,7 +25,7 @@ script
       mkdir ${METADATA_DRIVE_MOUNTPOINT}
     fi
     mount LABEL=METADATA ${METADATA_DRIVE_MOUNTPOINT} || {
-      echo no such labeled device: METADATA | logger
+      echo no such labeled device: METADATA | logger -t haproxy_updator
       exit 1
     }
   fi
@@ -34,9 +34,9 @@ script
 
   INSTANCE_ID=`cat ${METADATA_DRIVE_MOUNTPOINT}/meta-data/instance-id`
 
-  [ -z "${AMQP_SERVER}" ] && { echo "AMQP_SERVER is empty." | logger; exit 1; }
-  [ -z "${AMQP_PORT}"   ] && { echo   "AMQP_PORT is empty." | logger; exit 1; }
-  [ -z "${INSTANCE_ID}" ] && { echo "INSTANCE_ID is empty." | logger; exit 1; }
+  [ -z "${AMQP_SERVER}" ] && { echo "AMQP_SERVER is empty." | logger -t haproxy_updator; exit 1; }
+  [ -z "${AMQP_PORT}"   ] && { echo   "AMQP_PORT is empty." | logger -t haproxy_updator; exit 1; }
+  [ -z "${INSTANCE_ID}" ] && { echo "INSTANCE_ID is empty." | logger -t haproxy_updator; exit 1; }
 
   exec ${base_path}/amqptools/bin/amqpspawn \
    -f \

--- a/vmapp/load_balancer/etc/init/haproxy_updater.conf
+++ b/vmapp/load_balancer/etc/init/haproxy_updater.conf
@@ -38,12 +38,14 @@ script
     eval $i
   done
 
-  if [ "$AMQP_SERVER" != "" ] && [ "$AMQP_PORT" != "" ] && [ "${INSTANCE_ID}" != "" ]; then
-    ${base_path}/amqptools/bin/amqpspawn \
-    -f \
-    -h ${AMQP_SERVER} \
-    -P ${AMQP_PORT} amq.topic \
-    -q loadbalancer.${INSTANCE_ID} config.* \
-    -e ${base_path}/scripts/update_haproxy.sh
-  fi
+  [ -z "${AMQP_SERVER}" ] && { echo "AMQP_SERVER is empty." >&2; exit 1; }
+  [ -z "${AMQP_PORT}"   ] && { echo   "AMQP_PORT is empty." >&2; exit 1; }
+  [ -z "${INSTANCE_ID}" ] && { echo "INSTANCE_ID is empty." >&2; exit 1; }
+
+  ${base_path}/amqptools/bin/amqpspawn \
+   -f \
+   -h ${AMQP_SERVER} \
+   -P ${AMQP_PORT} amq.topic \
+   -q loadbalancer.${INSTANCE_ID} config.* \
+   -e ${base_path}/scripts/update_haproxy.sh
 end script

--- a/vmapp/load_balancer/etc/init/haproxy_updater.conf
+++ b/vmapp/load_balancer/etc/init/haproxy_updater.conf
@@ -25,7 +25,7 @@ script
       mkdir ${METADATA_DRIVE_MOUNTPOINT}
     fi
     mount LABEL=METADATA ${METADATA_DRIVE_MOUNTPOINT} || {
-      echo no such labeled device: METADATA | logger -t haproxy_updator
+      logger -t haproxy_updator "no such labeled device: METADATA"
       exit 1
     }
   fi
@@ -34,9 +34,9 @@ script
 
   INSTANCE_ID=`cat ${METADATA_DRIVE_MOUNTPOINT}/meta-data/instance-id`
 
-  [ -z "${AMQP_SERVER}" ] && { echo "AMQP_SERVER is empty." | logger -t haproxy_updator; exit 1; }
-  [ -z "${AMQP_PORT}"   ] && { echo   "AMQP_PORT is empty." | logger -t haproxy_updator; exit 1; }
-  [ -z "${INSTANCE_ID}" ] && { echo "INSTANCE_ID is empty." | logger -t haproxy_updator; exit 1; }
+  [ -z "${AMQP_SERVER}" ] && { logger -t haproxy_updator "AMQP_SERVER is empty."; exit 1; }
+  [ -z "${AMQP_PORT}"   ] && { logger -t haproxy_updator   "AMQP_PORT is empty."; exit 1; }
+  [ -z "${INSTANCE_ID}" ] && { logger -t haproxy_updator "INSTANCE_ID is empty."; exit 1; }
 
   exec ${base_path}/amqptools/bin/amqpspawn \
    -f \

--- a/vmapp/load_balancer/etc/init/haproxy_updater.conf
+++ b/vmapp/load_balancer/etc/init/haproxy_updater.conf
@@ -5,7 +5,7 @@ start on runlevel [2345]
 stop on runlevel [016]
 
 respawn
-respawn limit 5 60
+respawn limit unlimited
 
 chdir /opt/axsh/wakame-vdc/
 script

--- a/vmapp/load_balancer/etc/init/haproxy_updater.conf
+++ b/vmapp/load_balancer/etc/init/haproxy_updater.conf
@@ -9,8 +9,10 @@ respawn limit unlimited
 
 chdir /opt/axsh/wakame-vdc/
 script
-  # If a job is failed, upstart supervisor will run again soon. It's too fast.
-  # Because a proper sleep is needed.
+  # Sometimes this job failed before initializing networking with wakame-init.
+  #
+  # If this job is failed, upstart supervisor will run again soon. It's too fast.
+  # Therefore a proper sleep is needed.
   sleep ${SLEEP_SEC:-1}
 
   base_path=`pwd`
@@ -33,6 +35,9 @@ script
   fi
 
   . ${METADATA_DRIVE_MOUNTPOINT}/user-data
+  # $ cat /metadata/user-data
+  # AMQP_SERVER=10.0.2.2
+  # AMQP_PORT=5999
 
   INSTANCE_ID=`cat ${METADATA_DRIVE_MOUNTPOINT}/meta-data/instance-id`
 

--- a/vmapp/load_balancer/etc/init/haproxy_updater.conf
+++ b/vmapp/load_balancer/etc/init/haproxy_updater.conf
@@ -38,7 +38,7 @@ script
   [ -z "${AMQP_PORT}"   ] && { echo   "AMQP_PORT is empty." >&2; exit 1; }
   [ -z "${INSTANCE_ID}" ] && { echo "INSTANCE_ID is empty." >&2; exit 1; }
 
-  ${base_path}/amqptools/bin/amqpspawn \
+  exec ${base_path}/amqptools/bin/amqpspawn \
    -f \
    -h ${AMQP_SERVER} \
    -P ${AMQP_PORT} amq.topic \

--- a/vmapp/load_balancer/etc/init/haproxy_updater.conf
+++ b/vmapp/load_balancer/etc/init/haproxy_updater.conf
@@ -9,6 +9,10 @@ respawn limit unlimited
 
 chdir /opt/axsh/wakame-vdc/
 script
+  # If a job is failed, upstart supervisor will run again soon. It's too fast.
+  # Because a proper sleep is needed.
+  sleep ${SLEEP_SEC:-1}
+
   base_path=`pwd`
 
   METADATA_LOCATION=drive

--- a/vmapp/load_balancer/etc/init/haproxy_updater.conf
+++ b/vmapp/load_balancer/etc/init/haproxy_updater.conf
@@ -45,9 +45,5 @@ script
     -P ${AMQP_PORT} amq.topic \
     -q loadbalancer.${INSTANCE_ID} config.* \
     -e ${base_path}/scripts/update_haproxy.sh
-    exit 0
-  else
-    exit 1
   fi
-
 end script

--- a/vmapp/load_balancer/etc/init/haproxy_updater.conf
+++ b/vmapp/load_balancer/etc/init/haproxy_updater.conf
@@ -25,9 +25,7 @@ script
   done
 
   if [ $? != 0 ]; then
-    if [ ! -d ${METADATA_DRIVE_MOUNTPOINT} ]; then
-      mkdir ${METADATA_DRIVE_MOUNTPOINT}
-    fi
+    mkdir -p ${METADATA_DRIVE_MOUNTPOINT}
     mount LABEL=METADATA ${METADATA_DRIVE_MOUNTPOINT} || {
       logger -t haproxy_updator "no such labeled device: METADATA"
       exit 1


### PR DESCRIPTION
### Problem

Sometimes the `haproxy_updator` upstart system job failed before initializing networking with wakame-init.

### Possible Solution

1. change respawn limitation to unlimited
2. add a proper sleep time before executing new process
3. build new lb machine image

I've already gotten good result in #559.
So if this PR is merged, please close #559.
