### PR TITLE
fix relative path style and absolute path style.

### DIFF
--- a/client/mussel/bin/mussel
+++ b/client/mussel/bin/mussel
@@ -16,7 +16,7 @@ if [[ -d "${installed_path}" ]]; then
   PATH=${installed_path}:${PATH}
 else
   # non-rpm
-  PATH=${BASH_SOURCE[0]%%/*}/../:${PATH}
+  PATH=${BASH_SOURCE[0]%/*}/../:${PATH}
 fi
 
 mussel.sh "${@}"


### PR DESCRIPTION
### Problem

Current mussel wrapper does not support .

```
$ ./bin/mussel
./bin/mussel: line 22: mussel.sh: command not found
```

```
$ /home/hansode/work/repos/git/github.com/wakame-vdc/client/mussel/bin/mussel
/home/hansode/work/repos/git/github.com/wakame-vdc/client/mussel/bin/mussel: line 22: mussel.sh: command not found
```

### Possible Solution

Fix substring expansion for `PATH` environment value generator.

#### After fixing the problem

```
$ ./bin/mussel
./bin/../mussel.sh: line 35: /sbin/ip: No such file or directory
[ERROR] 'namespace' is empty (functions:248)
```

```
$ /home/hansode/work/repos/git/github.com/wakame-vdc/client/mussel/bin/mussel
/home/hansode/work/repos/git/github.com/wakame-vdc/client/mussel/bin/../mussel.sh: line 35: /sbin/ip: No such file or directory
[ERROR] 'namespace' is empty (functions:248)
```
