### PR TITLE
Fix LXC driver

### DIFF
--- a/dcmgr/lib/dcmgr/drivers/hypervisor/linux_hypervisor/linux_container/lxc.rb
+++ b/dcmgr/lib/dcmgr/drivers/hypervisor/linux_hypervisor/linux_container/lxc.rb
@@ -47,7 +47,7 @@ module Dcmgr
       end
 
       def initialize
-        @lxc_version = `lxc-version`.chomp.split(': ').last
+        @lxc_version = `lxc-info --version`.chomp.split(': ').last
         logger.info("lxc-version: #{@lxc_version}")
 
         unless check_cgroup_mount

--- a/dcmgr/lib/dcmgr/drivers/hypervisor/linux_hypervisor/linux_container/lxc.rb
+++ b/dcmgr/lib/dcmgr/drivers/hypervisor/linux_hypervisor/linux_container/lxc.rb
@@ -58,6 +58,10 @@ module Dcmgr
       def run_instance(ctx)
         # run lxc
         generate_config(ctx)
+
+        # check mount point
+        Dir.mkdir(ctx.root_mount_path) unless File.directory?(ctx.root_mount_path)
+        # "rootfs" directory should be created before running lxc-create.
         sh("lxc-create -f %s -n %s", [ctx.lxc_conf_path, ctx.inst[:uuid]])
 
         poweron_instance(ctx)
@@ -77,8 +81,6 @@ module Dcmgr
       end
 
       def poweron_instance(ctx)
-        # check mount point
-        Dir.mkdir(ctx.root_mount_path) unless File.directory?(ctx.root_mount_path)
         mount_root_image(ctx, ctx.root_mount_path)
 
         # metadata drive

--- a/dcmgr/lib/dcmgr/drivers/hypervisor/linux_hypervisor/linux_container/lxc.rb
+++ b/dcmgr/lib/dcmgr/drivers/hypervisor/linux_hypervisor/linux_container/lxc.rb
@@ -89,6 +89,7 @@ module Dcmgr
 
         sh("lxc-start -d -n %s", [ctx.inst[:uuid], ctx.inst_data_dir])
         sh("lxc-wait -n %s -s RUNNING", [ctx.inst_id])
+        ctx.logger.info("Started container")
       end
 
       def poweroff_instance(ctx)

--- a/dcmgr/lib/dcmgr/drivers/hypervisor/linux_hypervisor/linux_container/lxc.rb
+++ b/dcmgr/lib/dcmgr/drivers/hypervisor/linux_hypervisor/linux_container/lxc.rb
@@ -141,13 +141,10 @@ module Dcmgr
         end
 
         # `lxc-info -n i-abj0jbjk`.split
-        # => ["state:", "RUNNING", "pid:", "6253"]
-        #
-        # `lxc-info -n xxx`.split
-        # => ["state:", "STOPPED", "pid:", "-1"]
+        # => ["Name:", "i-wsriilld", "State:", "RUNNING", "PID:", "8292", "CPU", "use:", "1.33", "seconds", "Memory", "use:", "29.12", "MiB"]
 
-        container_status = `lxc-info -n #{i}`.split
-        if container_status[1] != "RUNNING"
+        container_status = `lxc-info -n #{i}`.chomp.split(" ")
+        if container_status[3] != "RUNNING"
           raise "Unable to find the lxc container: #{i}"
         end
       end

--- a/dcmgr/templates/lxc/lxc.conf
+++ b/dcmgr/templates/lxc/lxc.conf
@@ -15,8 +15,6 @@ lxc.pts = 1024
 lxc.rootfs = <%= "#{ctx.inst_data_dir}/rootfs" %>
 lxc.rootfs.mount = <%= "#{ctx.inst_data_dir}/rootfs" %>
 lxc.mount.entry = proc        /proc                   proc    defaults        0 0
-lxc.mount.entry = tmpfs       /dev/shm                tmpfs   defaults        0 0
-lxc.mount.entry = devpts      /dev/pts                devpts  gid=5,mode=620  0 0
 lxc.mount.entry = sysfs       /sys                    sysfs   defaults        0 0
 #lxc.mount = <%= "#{ctx.inst_data_dir}/fstab" %>
 #lxc.cap.drop = mac_admin sys_boot

--- a/dcmgr/templates/lxc/lxc.conf
+++ b/dcmgr/templates/lxc/lxc.conf
@@ -6,10 +6,6 @@ lxc.network.type = veth
 lxc.network.link = <%= bridge_if_name(vif[:ipv4][:network][:dc_network]) %>
 <%- end -%>
 
-# *** work-around ***
-# until virtual sysfs implementation
-lxc.network.name = <%= vif[:uuid] %>
-
 lxc.network.veth.pair = <%= vif[:uuid] %>
 lxc.network.hwaddr = <%= vif[:mac_addr].unpack('A2'*6).join(':') %>
 lxc.network.flags = up

--- a/dcmgr/templates/lxc/lxc.conf
+++ b/dcmgr/templates/lxc/lxc.conf
@@ -4,7 +4,6 @@ lxc.utsname = <%= ctx.inst_id %>
 lxc.network.type = veth
 <%- if vif[:ipv4] -%>
 lxc.network.link = <%= bridge_if_name(vif[:ipv4][:network][:dc_network]) %>
-lxc.network.ipv4 = <%= vif[:address] %>/<%= vif[:ipv4][:network][:prefix] %>
 <%- end -%>
 
 # *** work-around ***

--- a/rpmbuild/SPECS/wakame-vdc.spec
+++ b/rpmbuild/SPECS/wakame-vdc.spec
@@ -211,7 +211,7 @@ BuildArch: noarch
 Summary: Configuration set for hva LXC VM appliance
 Group: Development/Languages
 Requires: %{oname}-hva-common-vmapp-config = %{version}-%{release}
-Requires: lxc
+Requires: lxc >= 1.0.0
 %description  hva-lxc-vmapp-config
 <insert long description, indented with spaces>
 


### PR DESCRIPTION
### Problem

Current LXC driver is for `lxc-0.8.0`.

RHEL6 compabible environment uses EPEL yum repository as third-party package provider.
EPEL provides `lxc-1.0.x`. So nobody can get `lxc-0.8.0` without custom rpmbuild.

### Solution

Support `lxc-1.0.0`.

### Memo

Even if this change supports lxc-1.0.0, lxc driver does not support local-volume based instance.
In next step, lxc-driver should support local-volume based instance.

After merging this change, please create a new issue to support local-volume based instance.
