### PR TITLE
add sg index with/without service_type.

### DIFF
--- a/client/mussel/completion/mussel-completion.bash
+++ b/client/mussel/completion/mussel-completion.bash
@@ -235,6 +235,14 @@ _mussel() {
     security_group)
       case "${task}" in
         index)
+          case "${prev}" in
+            --service-type)
+              COMPREPLY=($(compgen -W "std lb" -- ${cur}))
+              ;;
+            *)
+              COMPREPLY=($(compgen -W "--service-type" -- ${cur}))
+              ;;
+          esac
           ;;
         create)
           case "${prev}" in

--- a/client/mussel/test/component/v12.03/t.security_group.sh
+++ b/client/mussel/test/component/v12.03/t.security_group.sh
@@ -16,6 +16,8 @@ declare rule_file=${BASH_SOURCE[0]%/*}/rule.$$.txt
 ## functions
 
 function setUp() {
+  xquery=
+  service_type=
   cat <<-EOS > ${rule_file}
 	icmp:-1,-1,ip4:0.0.0.0/0
 	tcp:22,22,ip4:0.0.0.0/0
@@ -25,6 +27,25 @@ function setUp() {
 
 function tearDown() {
   rm -f ${rule_file}
+}
+
+  state=
+
+### index
+
+function test_security_group_index_no_opts() {
+  local cmd=index
+  local service_type=
+  assertEquals "$(cli_wrapper ${namespace} ${cmd})" \
+               "curl -X GET $(base_uri)/${namespace}s.$(suffix)"
+}
+
+function test_security_group_index_opts() {
+  local cmd=index
+  local service_type=std
+
+  assertEquals "$(cli_wrapper ${namespace} ${cmd} --service-type=${service_type})" \
+               "curl -X GET $(base_uri)/${namespace}s.$(suffix)?service_type=${service_type}"
 }
 
 ### create

--- a/client/mussel/v12.03.d/security_group.sh
+++ b/client/mussel/v12.03.d/security_group.sh
@@ -5,6 +5,14 @@
 
 . ${BASH_SOURCE[0]%/*}/base.sh
 
+task_index() {
+  # --service-type=(std|lb)
+  if [[ -n "${service_type}" ]]; then
+    xquery="service_type=${service_type}"
+  fi
+  cmd_index $*
+}
+
 task_create() {
   call_api -X POST $(urlencode_data \
     $(add_param service_type    string) \


### PR DESCRIPTION
### Feature

This change will provide security_group `--service-type` option.

```
$ mussel security_group index --service-type [ std | lb ]
```

### How to use

```
$ mussel security_group index
$ mussel security_group index --service-type std
$ mussel security_group index --service-type lb
```
