### PR TITLE
Improve mussel helper retry

### DIFF
--- a/client/mussel/test/helpers/retry.sh
+++ b/client/mussel/test/helpers/retry.sh
@@ -48,7 +48,7 @@ function open_port?() {
     *) ;;
   esac
 
-  echo | nc ${nc_opts} ${ipaddr} ${port} >/dev/null
+  nc ${nc_opts} ${ipaddr} ${port} <<< "" >/dev/null
 }
 
 function network_connection?() {

--- a/client/mussel/test/helpers/retry.sh
+++ b/client/mussel/test/helpers/retry.sh
@@ -43,9 +43,9 @@ function open_port?() {
 
   local nc_opts="-w 3"
   case ${protocol} in
-  tcp) ;;
-  udp) nc_opts="${nc_opts} -u";;
-    *) ;;
+    tcp) ;;
+    udp) nc_opts="${nc_opts} -u";;
+      *) ;;
   esac
 
   nc ${nc_opts} ${ipaddr} ${port} <<< "" >/dev/null

--- a/client/mussel/test/helpers/retry.sh
+++ b/client/mussel/test/helpers/retry.sh
@@ -13,6 +13,7 @@ function retry_until() {
   local sleep_sec=${RETRY_SLEEP_SEC:-3}
   local tries=0
   local start_at=$(date +%s)
+  local chk_cmd=
 
   while :; do
     eval "${blk}" && {


### PR DESCRIPTION
### Problem

When running `set -u` enabled script which includes `retry.sh`, that scripts got following error:

```
/opt/axsh/wakame-vdc/client/mussel/test/helpers/retry.sh: line 29: chk_cmd: unbound variable
```

sample script:

```
$ cat inst-create.sh
#!/bin/bash
#
#
set -e
set -o pipefail
set -u

## include

. /opt/axsh/wakame-vdc/client/mussel/test/helpers/retry.sh

## test

type -P mussel >/dev/null

## shell params

cpu_cores=${cpu_cores:-1}
hypervisor=${hypervisor:-kvm}
image_id=${image_id:-wmi-centos1d64}
memory_size=${memory_size:-256}

ssh_key_id=${ssh_key_id:?"should not be empty"} # ssh-ytzd50zj
vifs=${vifs:-vifs.json}
user_data=${user_data-/dev/null} # user_data_mysqld.txt

## create an instance

instance_id="$(
  mussel instance create \
   --cpu-cores   ${cpu_cores}   \
   --hypervisor  ${hypervisor}  \
   --image-id    ${image_id}    \
   --memory-size ${memory_size} \
   --ssh-key-id  ${ssh_key_id}  \
   --vifs        ${vifs}        \
   --user-data   ${user_data}   \
  | egrep ^:id: | awk '{print $2}'
)"
: ${instance_id:?"instance is empty"}

## wait for the instance to be running

retry_until [[ '"$(mussel instance show "${instance_id}" | egrep -w "^:state: running")"' ]]
echo instance_id="${instance_id}"
```

### Improve

1. add proper indents
2. use here-string instead of echo & pipe to remove unnecessary "|"
