### PR TITLE
Docs fix custom image header

### DIFF
--- a/docs/content/usage/custom-machine-images.md
+++ b/docs/content/usage/custom-machine-images.md
@@ -1,4 +1,4 @@
-## Custom Machine Images
+## Overview
 
 Although there are a variety of pre-built machine images for Wakame-vdc, in
 most cases it will be necessary to install extra software and do other

--- a/docs/content/usage/custom-machine-images.md
+++ b/docs/content/usage/custom-machine-images.md
@@ -1,4 +1,4 @@
-## Overview
+## Custom Machine Images
 
 Although there are a variety of pre-built machine images for Wakame-vdc, in
 most cases it will be necessary to install extra software and do other

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -18,7 +18,7 @@ pages:
 #- ['configuration.md', 'Getting started', 'Configuration']
 - ['development.md', 'Getting started', 'Development']
 - ['usage/index.md', 'Usage', 'Basics']
-- ['usage/advanced.md', 'Usage', 'Advanced']
+- ['usage/custom-machine-images.md', 'Usage', 'Custom Machine Images']
 - ['instance-backup/index.md', 'Instance Backup', 'About']
 #- ['instance-backup/configuration.md', 'Instance Backup', 'Configuration']
 #- ['instance-backup/usage.md', 'Instance Backup', 'Usage']


### PR DESCRIPTION
The custom machine images guide was given the header `Advanced Usage`. This doesn't describe the guide accurately so I changed it to `Custom Machine Images`.