### PR TITLE
Docs unify format

### DIFF
--- a/docs/content/community.md
+++ b/docs/content/community.md
@@ -6,7 +6,7 @@ If you wish to contribute to this website, you will need to have a [Github](http
 
 This will not be a one-way conversation. We welcome (well argumented and respectful) discussions about what the documentation should be like. Once we're satisfied with your contribution, we will merge it and publish it to the main website.
 
-This site's development repository is located here: [https://github.com/axsh/wakame-vdc/docs](https://github.com/axsh/wakame-vdc/docs)
+This site's documentation repository is located here: [https://github.com/axsh/wakame-vdc/docs](https://github.com/axsh/wakame-vdc/docs)
 
 **Tip:** If you want to preview your changes locally, try running [mkdocs](http://www.mkdocs.org/).
 

--- a/docs/content/community.md
+++ b/docs/content/community.md
@@ -6,7 +6,7 @@ If you wish to contribute to this website, you will need to have a [Github](http
 
 This will not be a one-way conversation. We welcome (well argumented and respectful) discussions about what the documentation should be like. Once we're satisfied with your contribution, we will merge it and publish it to the main website.
 
-This site's development repository is located here: [https://github.com/axsh/wakame-vdc](https://github.com/axsh/wakame-vdc)
+This site's development repository is located here: [https://github.com/axsh/wakame-vdc/docs](https://github.com/axsh/wakame-vdc/docs)
 
 **Tip:** If you want to preview your changes locally, try running [mkdocs](http://www.mkdocs.org/).
 

--- a/docs/content/development.md
+++ b/docs/content/development.md
@@ -18,7 +18,7 @@ The file [dcmgr/lib/dcmgr.rb](https://github.com/axsh/wakame-vdc/blob/master/dcm
 
 The WebAPI code uses [Sinatra](http://www.sinatrarb.com) and is in the [dcmgr/lib/dcmgr/endpoints/12.03](https://github.com/axsh/wakame-vdc/tree/master/dcmgr/lib/dcmgr/endpoints/12.03) directory.
 
-#### Hypervisor drivers
+### Hypervisor drivers
 
 The code that actually starts instances is in the [dcmgr/lib/dcmgr/drivers/hypervisor](https://github.com/axsh/wakame-vdc/tree/master/dcmgr/lib/dcmgr/drivers/hypervisor) directory.
 

--- a/docs/content/development.md
+++ b/docs/content/development.md
@@ -14,7 +14,7 @@ The main backend source code is in the [dcmgr](https://github.com/axsh/wakame-vd
 
 The file [dcmgr/lib/dcmgr.rb](https://github.com/axsh/wakame-vdc/blob/master/dcmgr/lib/dcmgr.rb) provides a nice overview of the code. It shows the module and class structure.
 
-#### WebAPI
+### WebAPI
 
 The WebAPI code uses [Sinatra](http://www.sinatrarb.com) and is in the [dcmgr/lib/dcmgr/endpoints/12.03](https://github.com/axsh/wakame-vdc/tree/master/dcmgr/lib/dcmgr/endpoints/12.03) directory.
 
@@ -22,33 +22,33 @@ The WebAPI code uses [Sinatra](http://www.sinatrarb.com) and is in the [dcmgr/li
 
 The code that actually starts instances is in the [dcmgr/lib/dcmgr/drivers/hypervisor](https://github.com/axsh/wakame-vdc/tree/master/dcmgr/lib/dcmgr/drivers/hypervisor) directory.
 
-#### Scheduling
+### Scheduling
 
 All decisions that need to be made in order to start instances (assignment of [host node](jargon-dictionary.md#hva), IP address, MAC address, etc.) are referred to as scheduling and are located in the [dcmgr/lib/dcmgr/scheduler](https://github.com/axsh/wakame-vdc/tree/master/dcmgr/lib/dcmgr/scheduler) directory. The code that actually executes these schedulers can be found here: [dcmgr/lib/dcmgr/node_modules/scheduler.rb](https://github.com/axsh/wakame-vdc/blob/master/dcmgr/lib/dcmgr/node_modules/scheduler.rb)
 
-#### Security Groups
+### Security Groups
 
 The firewall ([Security Groups](security-groups/index.md)) related code is located in the [dcmgr/lib/dcmgr/edge_networking](https://github.com/axsh/wakame-vdc/tree/master/dcmgr/lib/dcmgr/edge_networking) directory. This code is executed from the following file: [dcmgr/lib/dcmgr/node_modules/service_netfilter.rb](https://github.com/axsh/wakame-vdc/blob/master/dcmgr/lib/dcmgr/node_modules/service_netfilter.rb).
 
 The [dcmgr/lib/dcmgr/edge_networking/openflow](https://github.com/axsh/wakame-vdc/tree/master/dcmgr/lib/dcmgr/edge_networking/openflow) directory is actually a leftover from an obsolete feature concerning virtual networks. That feature got split off and turned into [OpenVNet](https://github.com/axsh/openvnet). The directory is still there because [the NATbox](jargon-dictionary#natbox) uses [OpenFlow](http://archive.openflow.org) to provide network address translation.
 
-#### AMQP messaging
+### AMQP messaging
 
 Wakame-vdc uses an in-house developed framework that handles all the [AMQP](http://www.amqp.org) messaging. It's called Isono and can be found in its own [github repository](https://github.com/axsh/isono).
 
 The classes that implement Isono can be found in the [dcmgr/lib/dcmgr/node_modules](https://github.com/axsh/wakame-vdc/tree/master/dcmgr/lib/dcmgr/node_modules) and [dcmgr/lib/dcmgr/rpc](https://github.com/axsh/wakame-vdc/tree/master/dcmgr/lib/dcmgr/rpc) directories.
 
-#### Database access
+### Database access
 
 We use [Sequel](http://sequel.jeremyevans.net) to handle database access. The model classes are in the [dcmgr/lib/dcmgr/models](https://github.com/axsh/wakame-vdc/tree/master/dcmgr/lib/dcmgr/models) directory.
 
 The database schema is managed using [Sequel Migrations](http://sequel.jeremyevans.net/rdoc/files/doc/migration_rdoc.html). The migration files are in [config/db/migrations](https://github.com/axsh/wakame-vdc/tree/master/dcmgr/config/db/migrations).
 
-#### GUI
+### GUI
 
 The GUI is a [Rails](http://rubyonrails.org) application and is located in the [frontend/dcmgr_gui](https://github.com/axsh/wakame-vdc/tree/master/frontend/dcmgr_gui) directory. There's also a not quite as pretty admin GUI available if you want to play around with it. [frontend/admin](https://github.com/axsh/wakame-vdc/tree/master/frontend/admin)
 
-#### CLI (vdc-manage and gui-manage)
+### CLI (vdc-manage and gui-manage)
 
 Both CLI's used by Wakame-vdc are implemented using [Thor](http://whatisthor.com).
 
@@ -56,23 +56,23 @@ The *vdc-manage* CLI is located in the [dcmgr/lib/dcmgr/cli](https://github.com/
 
 The *gui-manage* CLI can be found in [frontend/dcmgr_gui/lib/cli](https://github.com/axsh/wakame-vdc/tree/master/frontend/dcmgr_gui/lib/cli) and is executed from [frontend/dcmgr_gui/bin/gui-manage](https://github.com/axsh/wakame-vdc/blob/master/frontend/dcmgr_gui/bin/gui-manage).
 
-#### Configuration files
+### Configuration files
 
 The configuration files use an in-house developed framework called [Fuguta](https://github.com/axsh/fuguta). Their definitions can be found in the [dcmgr/lib/dcmgr/configurations](https://github.com/axsh/wakame-vdc/tree/master/dcmgr/lib/dcmgr/configurations) directory. Examples of the configuration files themselves can be found here: [dcmgr/config](https://github.com/axsh/wakame-vdc/tree/master/dcmgr/config)
 
-#### RPM packaging
+### RPM packaging
 
 The RPM packaging scripts are in the aptly named [rpmbuild](https://github.com/axsh/wakame-vdc/tree/master/rpmbuild) directory.
 
-#### Debian packaging
+### Debian packaging
 
 You might notice a [debian](https://github.com/axsh/wakame-vdc/tree/master/debian) directory in the main repository. Even though the directory is there, Debian packaging is currently **not** officially supported. Feel free to play around with the packaging info in this directory but don't expect it to work.
 
-#### Mussel
+### Mussel
 
 Mussel is an API client and autotesting framework for Wakame-vdc written in bash. It can be found here: [client/mussel](https://github.com/axsh/wakame-vdc/tree/master/client/mussel)
 
-#### Autotesting
+### Autotesting
 
 There are currently three autotest suites for Wakame-vdc.
 
@@ -82,11 +82,11 @@ Integration tests using the Mussel framework are here: [client/mussel/test](http
 
 Integration tests using [RSpec](http://rspec.info) are here: [spec_integration](https://github.com/axsh/wakame-vdc/tree/master/spec_integration)
 
-#### Instance init scripts
+### Instance init scripts
 
 The instances need to be made aware of meta-data that Wakame-vdc sets for them like IP address, hostname, etc. Scripts to do this are located here: [wakame-init](https://github.com/axsh/wakame-vdc/tree/master/wakame-init)
 
-#### Upstart jobs
+### Upstart jobs
 
 The upstart jobs that are used to start Wakame-vdc services are located here: [contrib/etc](https://github.com/axsh/wakame-vdc/tree/master/contrib/etc)
 

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -1,14 +1,14 @@
 # F.A.Q.
 
-### What operating system will Wakame-vdc run on?
+## What operating system will Wakame-vdc run on?
 
 We are officially supporting Centos 6.6 x86 64 bit. It is possible that it'll run on other operating systems as well but this is the only one we're testing on. All current production environments also run on it.
 
-### Is Wakame-vdc currently being used in production anywhere?
+## Is Wakame-vdc currently being used in production anywhere?
 
 Yes, it is. Check our section on the [homepage](index.md) for references.
 
-### Can I run Wakame-vdc in a virtual machine?
+## Can I run Wakame-vdc in a virtual machine?
 
 Absolutely. We do it all the time in development.
 
@@ -16,7 +16,7 @@ It works really well when you use OpenVZ as your hypervisor. Since OpenVZ is a c
 
 Our [VirtualBox demo image](http://wakameusersgroup.org/demo_image.html) implements Wakame-vdc in a virtual machine using OpenVZ and our [installation guide](installation.md) can be used to do the same.
 
-### What Hypervisors does Wakame-vdc support?
+## What Hypervisors does Wakame-vdc support?
 
 Currently the following:
 
@@ -28,7 +28,7 @@ Currently the following:
 
   * [VMWare ESXi](http://www.vmware.com/products/esxi-and-esx/overview) (Experimental only)
 
-### What OS can I run on Wakame-vdc's instances?
+## What OS can I run on Wakame-vdc's instances?
 
 Depends on which hypervisor you use. If you use a container like OpenVZ or LXC, all instances will use the same kernel as your host OS. Therefore your instances will be running either the same OS as your host or something very close to it.
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -1,6 +1,6 @@
 ![Wakame logo](img/Wakame2-logo-large.png)
 
-### What is Wakame-vdc?
+## What is Wakame-vdc?
 
 There are a couple of ways you could answer this question.
 
@@ -21,7 +21,7 @@ The following companies are currently using Wakame-vdc in production.
 
 Don't hesitate to let us know if you also use Wakame-vdc.
 
-### Quick Start
+## Quick Start
 
 [Wakame-vdc pre-installed in VirtualBox](http://wakameusersgroup.org/demo_image.html)
 
@@ -31,7 +31,7 @@ This is the fastest most painless way to get yourself a working Wakame-vdc envir
 
 This guide will teach you how to install Wakame-vdc on your own server. The end result will be similar to the VirtualBox image but since you're installing everything yourself, you will learn much more about the different components that make up Wakame-vdc.
 
-### Contact us
+## Contact us
 
 The best way to contact us is to send an e-mail to the [Wakame Users Group](https://groups.google.com/forum/?hl=en-GB#!forum/wakame-ug) on Google Groups. Please don't hesitate to ask us any questions. We realise Wakame-vdc is difficult to set up and that our documentation is limited at this time. If you want to try it out, we'll do our best to help you.
 

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -1,6 +1,4 @@
-# Wakame-vdc install guide
-
-### What are we installing?
+## What are we installing?
 
 This guide will set up a basic Wakame-vdc environment on a single host. When we are done with this guide we will have the following features available:
 
@@ -12,7 +10,7 @@ This guide will set up a basic Wakame-vdc environment on a single host. When we 
 
   * We will be able to use either password or rsa key authentication when logging into instances.
 
-### Installation requirements
+## Installation requirements
 
   * A machine running [Centos](http://www.centos.org) 6.6 with x86 64 bit processor architecture. This can be either bare metal or a virtual machine. Instances are going to run as
 [OpenVZ](http://openvz.org/Main_Page) containers so you don't need to worry about nested virtualization.
@@ -28,15 +26,15 @@ This guide will set up a basic Wakame-vdc environment on a single host. When we 
 
   * Internet access. (to download rpm packages and machine images)
 
-### What will this guide do to my machine?
+## What will this guide do to my machine?
 
   * Since we are going to use [OpenVZ](http://openvz.org/Main_Page), we will install OpenVZ's [modified Linux kernel](http://en.wikipedia.org/wiki/OpenVZ#Kernel).
 
   * We are going to set up a [Linux Bridge](http://www.linuxfoundation.org/collaborate/workgroups/networking/bridge) and connect the host's network interface to it.
 
-### Let's get started
+## Let's get started
 
-#### Yum repository setup
+### Yum repository setup
 
 Add the official Wakame-vdc yum repository to `/etc/yum.repos.d`.
 
@@ -50,7 +48,7 @@ Install [EPEL](https://fedoraproject.org/wiki/EPEL). We need to pull some OpenVZ
 
     sudo yum install -y epel-release
 
-#### Install Dcmgr
+### Install Dcmgr
 
 The dcmgr package contains two things.
 
@@ -63,7 +61,7 @@ Install the dcmgr package with the following command.
 
     sudo yum install -y wakame-vdc-dcmgr-vmapp-config
 
-#### Install HVA
+### Install HVA
 
 The HVA (HyperVisor Agent) is the part of Wakame-vdc that actually starts instances. On a production environment, you would likely have several dedicated bare metal hosts for this. Right now we are
 just going to install one HVA on the same machine as dcmgr.
@@ -72,17 +70,17 @@ just going to install one HVA on the same machine as dcmgr.
 
     sudo yum install -y wakame-vdc-hva-openvz-vmapp-config
 
-#### Install webui
+### Install webui
 
 This is Wakame-vdc's GUI. It's actually a [Rails application](http://rubyonrails.org) that sits in front of the dcmgr web API.
 
     sudo yum install -y wakame-vdc-webui-vmapp-config
 
-#### Reboot to load OpenVZ kernel
+### Reboot to load OpenVZ kernel
 
 These Wakame-vdc packages have installed OpenVZ as a dependency. OpenVZ runs on a custom kernel. Reboot your machine so that kernel gets loaded.
 
-#### Set up bridged networking
+### Set up bridged networking
 
 Wakame-vdc uses bridged networking to allow users to connect to instances. We are going to set up a [Linux Bridge](http://www.linuxfoundation.org/collaborate/workgroups/networking/bridge) to
 attach instances to.

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -96,32 +96,38 @@ The network setup that this guide assumes places the host in the same network as
 
 Create the file `/etc/sysconfig/network-scripts/ifcfg-br0` with the following contents
 
-    DEVICE=br0
-    TYPE=Bridge
-    BOOTPROTO=static
-    ONBOOT=yes
-    NM_CONTROLLED=no
-    IPADDR=192.168.3.100
-    NETMASK=255.255.255.0
-    GATEWAY=192.168.3.1
-    DNS1=8.8.8.8
-    DELAY=0
+```bash
+DEVICE=br0
+TYPE=Bridge
+BOOTPROTO=static
+ONBOOT=yes
+NM_CONTROLLED=no
+IPADDR=192.168.3.100
+NETMASK=255.255.255.0
+GATEWAY=192.168.3.1
+DNS1=8.8.8.8
+DELAY=0
+```
 
 Next we need to attach `eth0` to the bridge. Modify the file `/etc/sysconfig/network-scripts/ifcfg-eth0` with the following contents.
 
 **Remark:** If your machine's network interface is called `eth1`, `wlan0` or something else, make sure to edit its file instead. (e.g. ifcfg-eth1, ifcfg-wlan0, etc.) Also make sure to modify the *DEVICE=* line accordingly
 
-    DEVICE="eth0"
-    ONBOOT="yes"
-    BRIDGE=br0
-    NM_CONTROLLED=no
+```bash
+DEVICE="eth0"
+ONBOOT="yes"
+BRIDGE=br0
+NM_CONTROLLED=no
+```
 
 Restart the network.
 
 **Be careful!** If you have made any mistakes setting up these files for your environment, this next command will cause networking to go down on your machine. Triple check these values if
 you're running this guide on a remote machine!
 
-    sudo service network restart
+```bash
+sudo service network restart
+```
 
 ### Configuration
 
@@ -141,29 +147,35 @@ After running the script and [optionally reserving ip addresses](#reserve-ip), s
 
 The different Wakame-vdc services require their own config files. Unfortunately they currently aren't automatically installed with the rpm packages. Until we have that fixed, you will have to copy them over manually.
 
-    sudo cp /opt/axsh/wakame-vdc/dcmgr/config/dcmgr.conf.example /etc/wakame-vdc/dcmgr.conf
+```bash
+sudo cp /opt/axsh/wakame-vdc/dcmgr/config/dcmgr.conf.example /etc/wakame-vdc/dcmgr.conf
 
-    sudo cp /opt/axsh/wakame-vdc/dcmgr/config/hva.conf.example /etc/wakame-vdc/hva.conf
+sudo cp /opt/axsh/wakame-vdc/dcmgr/config/hva.conf.example /etc/wakame-vdc/hva.conf
 
-    sudo cp /opt/axsh/wakame-vdc/frontend/dcmgr_gui/config/database.yml.example /etc/wakame-vdc/dcmgr_gui/database.yml
+sudo cp /opt/axsh/wakame-vdc/frontend/dcmgr_gui/config/database.yml.example /etc/wakame-vdc/dcmgr_gui/database.yml
 
-    sudo cp /opt/axsh/wakame-vdc/frontend/dcmgr_gui/config/dcmgr_gui.yml.example /etc/wakame-vdc/dcmgr_gui/dcmgr_gui.yml
+sudo cp /opt/axsh/wakame-vdc/frontend/dcmgr_gui/config/dcmgr_gui.yml.example /etc/wakame-vdc/dcmgr_gui/dcmgr_gui.yml
 
-    sudo cp /opt/axsh/wakame-vdc/frontend/dcmgr_gui/config/instance_spec.yml.example /etc/wakame-vdc/dcmgr_gui/instance_spec.yml
+sudo cp /opt/axsh/wakame-vdc/frontend/dcmgr_gui/config/instance_spec.yml.example /etc/wakame-vdc/dcmgr_gui/instance_spec.yml
 
-    sudo cp /opt/axsh/wakame-vdc/frontend/dcmgr_gui/config/load_balancer_spec.yml.example /etc/wakame-vdc/dcmgr_gui/load_balancer_spec.yml
+sudo cp /opt/axsh/wakame-vdc/frontend/dcmgr_gui/config/load_balancer_spec.yml.example /etc/wakame-vdc/dcmgr_gui/load_balancer_spec.yml
+```
 
 #### Create the Wakame-vdc database
 
 Wakame-vdc uses a [MySQL](http://www.mysql.com) database. Start MySQL and create the database.
 
-    sudo service mysqld start
-    mysqladmin -uroot create wakame_dcmgr
+```
+sudo service mysqld start
+mysqladmin -uroot create wakame_dcmgr
+```
 
 We can use [Rake](https://github.com/ruby/rake) to create the database tables. Wakame-vdc comes with its own ruby binary that includes Rake.
 
-    cd /opt/axsh/wakame-vdc/dcmgr
-    /opt/axsh/wakame-vdc/ruby/bin/rake db:up
+```bash
+cd /opt/axsh/wakame-vdc/dcmgr
+/opt/axsh/wakame-vdc/ruby/bin/rake db:up
+```
 
 #### Register the HVA
 
@@ -173,21 +185,25 @@ Wakame-vdc recognises host nodes by their `node id`. That is a unique id that [A
 
 Edit the file `/etc/default/vdc-hva` and uncomment the following line:
 
-    NODE_ID=demo1
+```bash
+NODE_ID=demo1
+```
 
 Now our HVA process will start up with `demo1` as its `node id`. Next we need to add a database entry to let Wakame-vdc know how much memory, CPU power and disk space it has available, etc.
 
 We can use the `vdc-manage` cli to do this. Of course the parameters of this command will vary depending on the capacity of your HVA. Adjust them accordingly.
 
-    /opt/axsh/wakame-vdc/dcmgr/bin/vdc-manage host add hva.demo1 \
-       --uuid hn-demo1 \
-       --display-name "demo HVA 1" \
-       --cpu-cores 100 \
-       --memory-size 10240 \
-       --hypervisor openvz \
-       --arch x86_64 \
-       --disk-space 102400 \
-       --force
+```bash
+/opt/axsh/wakame-vdc/dcmgr/bin/vdc-manage host add hva.demo1 \
+   --uuid hn-demo1 \
+   --display-name "demo HVA 1" \
+   --cpu-cores 100 \
+   --memory-size 10240 \
+   --hypervisor openvz \
+   --arch x86_64 \
+   --disk-space 102400 \
+   --force
+```
 
 Remarks:
   * The `node id` would be *hva.demo1*. We set *demo1* in the above step but when the process starts, it is automatically prefixed by *hva*.
@@ -204,53 +220,67 @@ Of course we can't start any instances if we don't have a machine image to insta
 
 Wakame-vdc's default directory for keeping images is `/var/lib/wakame-vdc/images`. Create it.
 
-    sudo mkdir -p /var/lib/wakame-vdc/images
+```bash
+sudo mkdir -p /var/lib/wakame-vdc/images
+```
 
 Now download the image in that directory.
 
-    cd /var/lib/wakame-vdc/images
-    sudo curl -O http://dlc.wakame.axsh.jp.s3.amazonaws.com/demo/vmimage/ubuntu-lucid-kvm-md-32.raw.gz
+```bash
+cd /var/lib/wakame-vdc/images
+sudo curl -O http://dlc.wakame.axsh.jp.s3.amazonaws.com/demo/vmimage/ubuntu-lucid-kvm-md-32.raw.gz
+```
 
 The image should have the following md5 sum. We will need it when registering it in the database.
 
-    1f841b195e0fdfd4342709f77325ce29  ubuntu-lucid-kvm-md-32.raw.gz
+```bash
+1f841b195e0fdfd4342709f77325ce29  ubuntu-lucid-kvm-md-32.raw.gz
+```
 
 Now we need to let Wakame-vdc know that it has a machine image to start instances from. First of all here's a brief explanation of how Wakame-vdc treats machine images. There are two terms we'll need to understand here. **Backup objects** and **machine images**. A *backup object* is basically a hard drive image. A *machine image* is a backup object that's bootable. In case of a linux instance, the *machine image* would hold the root partition.
 
 To register both the *backup object* and the related *machine image*, we will again use the `vdc-manage` cli but since we are going to run more than one operation now, it's more efficient to call it without arguments. This will result in a special shell where we can run `vdc-manage` commands. This is more efficient because we only need to establish a connection to the database once and can then feed many commands through it.
 
-    /opt/axsh/wakame-vdc/dcmgr/bin/vdc-manage
+```bash
+/opt/axsh/wakame-vdc/dcmgr/bin/vdc-manage
+```
 
 First of all we need to tell Wakame-vdc how we are storing these *backup objects*. We are currently just keeping them on the local file system.
 
-    backupstorage add \
-      --uuid bkst-local \
-      --display-name "local storage" \
-      --base-uri "file:///var/lib/wakame-vdc/images/" \
-      --storage-type local \
-      --description "storage on the local filesystem"
+```bash
+backupstorage add \
+  --uuid bkst-local \
+  --display-name "local storage" \
+  --base-uri "file:///var/lib/wakame-vdc/images/" \
+  --storage-type local \
+  --description "storage on the local filesystem"
+```
 
 Now register the backup object and assign it to the local storage that we just made.
 
 This image is compressed with gzip to save space. In order to properly manage its disk space usage, Wakame-vdc needs to know both the compressed size and uncompressed size of the image. These translate to the *size* and *allocation-size* options respectively.
 
-    backupobject add \
-      --uuid bo-lucid5d \
-      --display-name "Ubuntu 10.04 (Lucid Lynx) root partition" \
-      --storage-id bkst-local \
-      --object-key ubuntu-lucid-kvm-md-32.raw.gz \
-      --size 149084 \
-      --allocation-size 359940 \
-      --container-format gz \
-      --checksum 1f841b195e0fdfd4342709f77325ce29
+```bash
+backupobject add \
+  --uuid bo-lucid5d \
+  --display-name "Ubuntu 10.04 (Lucid Lynx) root partition" \
+  --storage-id bkst-local \
+  --object-key ubuntu-lucid-kvm-md-32.raw.gz \
+  --size 149084 \
+  --allocation-size 359940 \
+  --container-format gz \
+  --checksum 1f841b195e0fdfd4342709f77325ce29
+```
 
 Next we tell Wakame-vdc that this backup object is a machine image that we can start instances of.
 
-    image add local bo-lucid5d \
-      --account-id a-shpoolxx \
-      --uuid wmi-lucid5d \
-      --root-device uuid:148bc5df-3fc5-4e93-8a16-7328907cb1c0 \
-      --display-name "Ubuntu 10.04 (Lucid Lynx)"
+```bash
+image add local bo-lucid5d \
+  --account-id a-shpoolxx \
+  --uuid wmi-lucid5d \
+  --root-device uuid:148bc5df-3fc5-4e93-8a16-7328907cb1c0 \
+  --display-name "Ubuntu 10.04 (Lucid Lynx)"
+```
 
 #### Register a network
 
@@ -258,57 +288,73 @@ Wakame-vdc needs to know which network instances will be connected to. You can r
 
 **Remark:** As described above, this guide assumes that network to be `192.168.3.0/24`. Make sure to change these values if you intend to use another network.
 
-    network add \
-      --uuid nw-demo1 \
-      --ipv4-network 192.168.3.0 \
-      --prefix 24 \
-      --ipv4-gw 192.168.3.1 \
-      --dns 8.8.8.8 \
-      --account-id a-shpoolxx \
-      --display-name "demo network"
+```bash
+network add \
+  --uuid nw-demo1 \
+  --ipv4-network 192.168.3.0 \
+  --prefix 24 \
+  --ipv4-gw 192.168.3.1 \
+  --dns 8.8.8.8 \
+  --account-id a-shpoolxx \
+  --display-name "demo network"
+```
 
 Wakame-vdc is now aware of this network but it still doesn't know which IP addresses in it are available to assign to instances. Register a dhcp range.
 
-    network dhcp addrange nw-demo1 192.168.3.1 192.168.3.254
+```bash
+network dhcp addrange nw-demo1 192.168.3.1 192.168.3.254
+```
 
 <a name="reserve-ip"></a>
 You might be worried because the gateway is included in dhcp range. Don't be. Wakame-vdc is smart enough to know that it can't use that IP address.
 
 If you have other IP addresses inside the dhcp range that can not be used by Wakame-vdc, you need to reserve them so Wakame-vdc knows these can't be used. For example in this guide we were using 192.168.3.100 as the host node's ip address and therefore it can not be used. You can reserve it with the following command. If you do not have any IP addresses that need to be reserved, just skip this step.
 
-    network reserve nw-demo1 --ipv4 192.168.3.100
+```bash
+network reserve nw-demo1 --ipv4 192.168.3.100
+```
 
 Wakame-vdc needs to know which mac addresses are available to assign to instances.
 
-    macrange add 525400 1 ffffff --uuid mr-demomacs
+```bash
+macrange add 525400 1 ffffff --uuid mr-demomacs
+```
 
 Next, Wakame-vdc needs to know which bridge to attach its intances' virtual network interfaces (vnics) to, and which interface on that bridge is connected to the outside world. You do that by registering a `dc network`.
 
-    network dc add public --uuid dcn-public --description "the network instances are started in"
-    network dc add-network-mode public securitygroup
-    network forward nw-demo1 public
+```bash
+network dc add public --uuid dcn-public --description "the network instances are started in"
+network dc add-network-mode public securitygroup
+network forward nw-demo1 public
+```
 
 We're done with vdc-manage. Exit its shell.
 
-    exit
+```bash
+exit
+```
 
 Earlier in this guide we have set up a bridge named `br0` and it's connected to the outside world through a network interface `eth0`. If you are also using these names, you should be fine.
 
 *If* you are using other names, you need to go update `/etc/wakame-vdc/hva.conf`. Find the following in that file and change it to match the names that you're using.
 
-    dc_network('public') {
-      bridge_type 'linux'
-      interface 'eth0'
-      bridge 'br0'
-    }
+```ruby
+dc_network('public') {
+  bridge_type 'linux'
+  interface 'eth0'
+  bridge 'br0'
+}
+```
 
 #### Configure the GUI
 
 The GUI is a rails application that requires its own database. Create it and initialize its tables using Rake.
 
-    mysqladmin -uroot create wakame_dcmgr_gui
-    cd /opt/axsh/wakame-vdc/frontend/dcmgr_gui/
-    /opt/axsh/wakame-vdc/ruby/bin/rake db:init
+```bash
+mysqladmin -uroot create wakame_dcmgr_gui
+cd /opt/axsh/wakame-vdc/frontend/dcmgr_gui/
+/opt/axsh/wakame-vdc/ruby/bin/rake db:init
+```
 
 The GUI uses user/password authentication. Wakame-vdc's web API has no authentication so on a production environment, you'd want to show only the GUI to the outside world while keeping the web API on a private network.
 
@@ -322,42 +368,58 @@ Users and accounts share a many-to-many relation. A user can belong to many acco
 
 The GUI database has a cli called `gui-manage` which is similar to vdc-manage.
 
-    /opt/axsh/wakame-vdc/frontend/dcmgr_gui/bin/gui-manage
+```bash
+/opt/axsh/wakame-vdc/frontend/dcmgr_gui/bin/gui-manage
+```
 
 Let's use it to create an account for ourselves. This account with uuid `a-shpoolxx` is a special account that Wakame-vdc uses for certain shared resources.
 
-    account add --name default --uuid a-shpoolxx
+```bash
+account add --name default --uuid a-shpoolxx
+```
 
 Next we'll add a user. The *login-id* is the name we're going to use when logging into the GUI.
 
-    user add --name "demo user" --uuid u-demo --password demo --login-id demo
+```bash
+user add --name "demo user" --uuid u-demo --password demo --login-id demo
+```
 
 Now associate the user and the account.
 
-    user associate u-demo --account-ids a-shpoolxx
+```bash
+user associate u-demo --account-ids a-shpoolxx
+```
 
 We're done with gui-manage. Exit the shell.
 
-    exit
+```bash
+exit
+```
 
 ### Start Wakame-vdc
 
 Start the rabbitmq server. Wakame-vdc's different processes use AMQP to communicate. Rabbitmq-server is the AMQP exchange managing all that traffic.
 
-    sudo service rabbitmq-server start
+```bash
+sudo service rabbitmq-server start
+```
 
 If you've been following this guide, MySQL should still be running. If it isn't running, start it.
 
-    sudo service mysqld start
+```bash
+sudo service mysqld start
+```
 
 After all this hard work we should be able to get Wakame-vdc up and running. Start the upstart jobs.
 
 These 4 upstart jobs can be started in any order as long as *rabbitmq-server* and *mysqld* have been started first.
 
-    sudo start vdc-dcmgr
-    sudo start vdc-collector
-    sudo start vdc-hva
-    sudo start vdc-webui
+```bash
+sudo start vdc-dcmgr
+sudo start vdc-collector
+sudo start vdc-hva
+sudo start vdc-webui
+```
 
 If everything went right, Wakame-vdc is now up and running. Start a web browser and surf to your machine's IP address on port 9000. If you're using the same IP address as this guide, that would be `192.168.3.100:9000`. Log in with user `demo` and password `demo`.
 

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -123,11 +123,11 @@ you're running this guide on a remote machine!
 
     sudo service network restart
 
-#### Configuration
+### Configuration
 
 Next we are going to configure Wakame-vdc and download a machine image containing Ubuntu 10.04 that we can start instances of. You can either do it manually or run a script we have provided. Both methods will amount to the same result. The script should be easier but doing it manually will teach you more about Wakame-vdc.
 
-##### Using the script
+#### Using the script
 
 The script can be found here: [install_guide_demo_data.sh](https://raw.githubusercontent.com/axsh/wakame-vdc/master/scripts/install_guide_demo_data.sh)
 
@@ -137,7 +137,7 @@ You need to tell it about the network you want to start your instances in. Run t
 
 After running the script and [optionally reserving ip addresses](#reserve-ip), skip over to the [Start Wakame-vdc](#start-wakame-vdc) section.
 
-##### Manual configuration
+#### Manual configuration
 
 The different Wakame-vdc services require their own config files. Unfortunately they currently aren't automatically installed with the rpm packages. Until we have that fixed, you will have to copy them over manually.
 
@@ -153,7 +153,7 @@ The different Wakame-vdc services require their own config files. Unfortunately 
 
     sudo cp /opt/axsh/wakame-vdc/frontend/dcmgr_gui/config/load_balancer_spec.yml.example /etc/wakame-vdc/dcmgr_gui/load_balancer_spec.yml
 
-##### Create the Wakame-vdc database
+#### Create the Wakame-vdc database
 
 Wakame-vdc uses a [MySQL](http://www.mysql.com) database. Start MySQL and create the database.
 
@@ -165,7 +165,7 @@ We can use [Rake](https://github.com/ruby/rake) to create the database tables. W
     cd /opt/axsh/wakame-vdc/dcmgr
     /opt/axsh/wakame-vdc/ruby/bin/rake db:up
 
-##### Register the HVA
+#### Register the HVA
 
 As describe above, the HVA or host node is the part of Wakame-vdc that actually starts instances. Wakame-vdc can manage any number of these. The words HVA and host node will be use interchangeably in this guide.
 
@@ -198,7 +198,7 @@ Remarks:
 
   * The *force* flag is set so we can register the host node even though Wakame-vdc can't currently see it through AMQP. Since we haven't started the Wakame-vdc services yet, it's only natural that it can't see it yet. It will once we start them.
 
-##### Download and register a machine image
+#### Download and register a machine image
 
 Of course we can't start any instances if we don't have a machine image to instantiate. For this guide we are just going to download a simple machine image containing Ubuntu 10.04 (Lucid Lynx).
 
@@ -252,7 +252,7 @@ Next we tell Wakame-vdc that this backup object is a machine image that we can s
       --root-device uuid:148bc5df-3fc5-4e93-8a16-7328907cb1c0 \
       --display-name "Ubuntu 10.04 (Lucid Lynx)"
 
-##### Register a network
+#### Register a network
 
 Wakame-vdc needs to know which network instances will be connected to. You can register more than one network and then decide which one to use when you start instances.
 
@@ -302,7 +302,7 @@ Earlier in this guide we have set up a bridge named `br0` and it's connected to 
       bridge 'br0'
     }
 
-##### Configure the GUI
+#### Configure the GUI
 
 The GUI is a rails application that requires its own database. Create it and initialize its tables using Rake.
 
@@ -340,7 +340,7 @@ We're done with gui-manage. Exit the shell.
 
     exit
 
-#### Start Wakame-vdc
+### Start Wakame-vdc
 
 Start the rabbitmq server. Wakame-vdc's different processes use AMQP to communicate. Rabbitmq-server is the AMQP exchange managing all that traffic.
 

--- a/docs/content/instance-backup/index.md
+++ b/docs/content/instance-backup/index.md
@@ -1,38 +1,44 @@
-# Backup instances
-
-### Overview
+## Overview
 
 In Wakame-vdc it is possible to take a running [instance](../jargon-dictionary.md#instance) and turn it into a new [machine image](../jargon-dictionary.md#machine-image). We simply call this process *backup*.
 
 This is a quick and easy way to create new machine images. For example, you could start up an instance, install a web server in it and then back it up. Now you'll have a machine image with a web server installed and you'll immediately be able to start a any amount of web server instances.
 
-### Requirements
+## Requirements
 
 You of course need a working Wakame-vdc installation. You can use either the [VirtualBox demo image](http://wakameusersgroup.org/demo_image.html) or create your own environment using the [installation guide](../installation.md).
 
-You need to tell Wakame-vdc which [backup storage](../jargon-dictionary.md#backup-storage] to use when backing up instances. Both the VirtualBox image and the installation guide will set that up but just in case, here it is again.
+You need to tell Wakame-vdc which [backup storage](../jargon-dictionary.md#backup-storage) to use when backing up instances. Both the VirtualBox image and the installation guide will set that up but just in case, here it is again.
 
 Figure out which backup storage you want to use with `vdc-manage`.
 
-    /opt/axsh/wakame-vdc/dcmgr/bin/vdc-manage backupstorage show
+```bash
+/opt/axsh/wakame-vdc/dcmgr/bin/vdc-manage backupstorage show
+```
 
 On an environment installed according to the installation guide, it will have this output
 
-    UUID            Storage Type         Base URI
-    bkst-local      local                file:///var/lib/wakame-vdc/images/
+```bash
+UUID            Storage Type         Base URI
+bkst-local      local                file:///var/lib/wakame-vdc/images/
+```
 
 There's only one backup storage defined and its UUID is `bkst-local`. We need to make sure this is set in `dcmgr.conf`.
 
-    grep backup_storage_id /etc/wakame-vdc/dcmgr.conf
+```bash
+grep backup_storage_id /etc/wakame-vdc/dcmgr.conf
+```
 
 That command should have an output similar to this.
 
-    backup_storage_id 'bkst-local'
+```bash
+backup_storage_id 'bkst-local'
+```
 
 If it does not show the UUID of the backup storage you want to use, open the file with a text editor and change that line.
 
 
-### Usage
+## Usage
 
 You need to have started an [instance](../jargon-dictionary.md#instance) in order to back it up. If you don't know how to start an instance, you can find the instructions in [the basic usage guide](../usage/index.md).
 

--- a/docs/content/security-groups/index.md
+++ b/docs/content/security-groups/index.md
@@ -1,15 +1,5 @@
 # Security Groups
 
-### Contents
-
-* [Overview](#Overview)
-* [Features](#Features)
-  - [Isolation](#Isolation)
-  - [Rules](#Rules)
-  - [Reference](#Reference)
-* [Creating security groups using the Wakame-vdc GUI](#Creating-security-groups-using-the-Wakame-vdc-GUI)
-* [Adding and removing vnics from security groups using the Wakame-vdc GUI](#Adding-and-removing-vnics-from-security-groups-using-the-Wakame-vdc-GUI)
-
 ### Overview
 
 In Wakame-vdc, every virtual network interface (vnic) will have its own firewall. These firewalls are implemented using [Netfilter](http://www.netfilter.org). Even if one instance has multiple vnics, they will still each have their own firewall.

--- a/docs/content/security-groups/index.md
+++ b/docs/content/security-groups/index.md
@@ -1,6 +1,4 @@
-# Security Groups
-
-### Overview
+## Overview
 
 In Wakame-vdc, every virtual network interface (vnic) will have its own firewall. These firewalls are implemented using [Netfilter](http://www.netfilter.org). Even if one instance has multiple vnics, they will still each have their own firewall.
 
@@ -14,7 +12,7 @@ Security groups are dynamic. Instances can enter and leave groups on the fly and
 
 ![screenshot](img/security-groups/high_level_overview.png)
 
-### Features
+## Features
 
 Security groups come with three distinct features.
 
@@ -24,7 +22,7 @@ Security groups come with three distinct features.
 
 **Remark:** Technically we don't put instances in security groups. We put their virtual network interfaces (vnics) in security groups. An instance with multiple vnics is able to have different security groups for each vnic.
 
-#### Isolation
+### Isolation
 
 By default all instances are isolated from each other. That means that all L2 traffic including ARP and IPv4 between them is blocked.
 
@@ -36,7 +34,7 @@ The following image shows a couple of instances with vnics in different security
 
 ![screenshot](img/security-groups/isolation.png)
 
-#### Rules
+### Rules
 
 By default all incoming traffic to instances is blocked. Security Group rules allow you to open specific TCP ports, UDP ports, or ICMP traffic.
 
@@ -44,7 +42,7 @@ The following image shows an example of a security group that opens TCP port 22 
 
 ![screenshot](img/security-groups/rules.png)
 
-##### Syntax
+#### Syntax
 
 For TCP and UDP protocols:
 
@@ -78,7 +76,7 @@ A rule that accepts *network unreachable* ICMP messages (type/code: 3/0) from ip
 
     icmp:3,0,ip4:192.168.2.1
 
-#### Reference
+### Reference
 
 A reference rule is a special type of rule. Instead of opening up a port to an ip range, you can open up a port to another security group. Take the following example.
 
@@ -88,7 +86,7 @@ This is where reference comes in. Reference allows you to put the database serve
 
 ![screenshot](img/security-groups/reference.png)
 
-##### Syntax
+#### Syntax
 
 The instances is the same as regular rules, except you write another security group's uuid insetad of an IP address.
 
@@ -100,7 +98,7 @@ For this example two security groups exist. *sg-dbsrv* which has the database se
 
     tcp:3306,3306,sg-dbclnts
 
-### Creating security groups using the Wakame-vdc GUI
+## Creating security groups using the Wakame-vdc GUI
 
 After logging into the GUI, click on `Security Groups` in the menu on the left. Next click on `Create Security Group`.
 
@@ -110,7 +108,7 @@ The following dialog will pop up. In here you will be able to write rules for yo
 
 ![screenshot](img/security-groups/07_security_groups_dialog.png)
 
-### Adding and removing vnics from security groups using the Wakame-vdc GUI
+## Adding and removing vnics from security groups using the Wakame-vdc GUI
 
 When starting an instance using the Wakame-vdc GUI, you will be required to put its vnic(s) in at least one security group. Although it is possible to start instances with vnic(s) that aren't in any security groups (which results in all incoming network traffic being blocked) by querying the WebAPI directly, the GUI requires one or more to be set.
 

--- a/docs/content/usage/custom-machine-images.md
+++ b/docs/content/usage/custom-machine-images.md
@@ -58,25 +58,25 @@ The first few commands log into the demo VM and download a template image:
 
     ssh centos@a.b.c.d  # where a.b.c.d is the demo VM's IP address
     [centos@wakame-vdc-1box ~]$ sudo su
-    [root@wakame-vdc-1box centos]# cd /vz/template/cache
-    [root@wakame-vdc-1box cache]# wget http://download.openvz.org/template/precreated/centos-6-x86_64-minimal.tar.gz
+    [root@wakame-vdc-1box centos]$ cd /vz/template/cache
+    [root@wakame-vdc-1box cache]$ wget http://download.openvz.org/template/precreated/centos-6-x86_64-minimal.tar.gz
 
 Next, an OpenVZ container based on this image is started.
 Note that the 101 that appears many times below can be any number that
 is not in use by OpenVZ.
 
-    [root@wakame-vdc-1box cache]# vzctl create 101 --ostemplate centos-6-x86_64-minimal --ipadd a.b.c.vv --hostname localhost
-    [root@wakame-vdc-1box cache]# vzctl set 101 --nameserver 8.8.8.8 --save
-    [root@wakame-vdc-1box cache]# vzctl start 101
+    [root@wakame-vdc-1box cache]$ vzctl create 101 --ostemplate centos-6-x86_64-minimal --ipadd a.b.c.vv --hostname localhost
+    [root@wakame-vdc-1box cache]$ vzctl set 101 --nameserver 8.8.8.8 --save
+    [root@wakame-vdc-1box cache]$ vzctl start 101
 
 Now we can go inside the container and specialize it by installing and
 configuring software.
 
-    [root@wakame-vdc-1box cache]# vzctl enter 101
-    [root@localhost /]# yum install httpd
-    [root@localhost /]# echo "<html>An Example top web page.</html>" >/var/www/html/index.html
-    [root@localhost /]# service httpd start
-    [root@localhost /]# chkconfig httpd on
+    [root@wakame-vdc-1box cache]$ vzctl enter 101
+    [root@localhost /]$ yum install httpd
+    [root@localhost /]$ echo "<html>An Example top web page.</html>" >/var/www/html/index.html
+    [root@localhost /]$ service httpd start
+    [root@localhost /]$ chkconfig httpd on
 
 ### Step 3: Specialize the OS installation for Wakame-vdc
 
@@ -123,17 +123,17 @@ not have this file.
 
 Exit the OpenVZ container.
 
-    [root@localhost etc]# exit
+    [root@localhost etc]$ exit
 
 Now we are back at the demo box prompt. The following instructions are adapted from
 the [OpenVZ wiki](http://wiki.openvz.org/Updating_Ubuntu_template):
 
-    [root@wakame-vdc-1box cache]# vzctl stop 101
-    [root@wakame-vdc-1box cache]# vzctl set 101 --ipdel all --save
-    [root@wakame-vdc-1box cache]# cd /vz/private/101
-    [root@wakame-vdc-1box 101]# tar  --numeric-owner -czf /vz/template/cache/new-custom-image-temp.tar.gz .
-    [root@wakame-vdc-1box 101]# cd ..
-    [root@wakame-vdc-1box private]# vzctl destroy 101
+    [root@wakame-vdc-1box cache]$ vzctl stop 101
+    [root@wakame-vdc-1box cache]$ vzctl set 101 --ipdel all --save
+    [root@wakame-vdc-1box cache]$ cd /vz/private/101
+    [root@wakame-vdc-1box 101]$ tar  --numeric-owner -czf /vz/template/cache/new-custom-image-temp.tar.gz .
+    [root@wakame-vdc-1box 101]$ cd ..
+    [root@wakame-vdc-1box private]$ vzctl destroy 101
 
 Wakame-vdc's preferred method of packaging machine images is inside of
 partitioned VM images files. The following commands show one way to
@@ -145,8 +145,8 @@ directory and create a 10G empty image there. Other directories will
 work. The advantage of choosing this directory is so that the image
 file will already be in the right place for testing with Wakame-vdc.
 
-    [root@wakame-vdc-1box private]# cd /var/lib/wakame-vdc/images/
-    [root@wakame-vdc-1box images]# truncate -s 10G wakame-vdc-custom-image.raw
+    [root@wakame-vdc-1box private]$ cd /var/lib/wakame-vdc/images/
+    [root@wakame-vdc-1box images]$ truncate -s 10G wakame-vdc-custom-image.raw
 
 The next commands add a partition table to the image, and then make
 the first partition be an ext2 partition (i.e. which in this context,
@@ -154,28 +154,28 @@ means any Linux partition) that takes up the whole image, except
 the first 63 sectors.  The new unformatted partition is then mounted
 on a loop device.
 
-    [root@wakame-vdc-1box images]# parted wakame-vdc-custom-image.raw mklabel msdos
-    [root@wakame-vdc-1box images]# parted --script -- wakame-vdc-custom-image.raw mkpart primary ext2 63s -0
-    [root@wakame-vdc-1box images]# kpartx -va wakame-vdc-custom-image.raw
+    [root@wakame-vdc-1box images]$ parted wakame-vdc-custom-image.raw mklabel msdos
+    [root@wakame-vdc-1box images]$ parted --script -- wakame-vdc-custom-image.raw mkpart primary ext2 63s -0
+    [root@wakame-vdc-1box images]$ kpartx -va wakame-vdc-custom-image.raw
 
 Next, the mounted partition is formatted and then mounted.  Note:
 Before doing this next command, be sure the output from previous
 kpartx command says that the partition was mounted at loop0p1, and if
 not adjust the parameter accordingly.
 
-    [root@wakame-vdc-1box images]# mkfs.ext4 -F -E lazy_itable_init=1 -L root /dev/mapper/loop0p1
-    [root@wakame-vdc-1box images]# tune2fs -o acl /dev/mapper/loop0p1
-    [root@wakame-vdc-1box images]# mkdir tmp-mount
-    [root@wakame-vdc-1box images]# mount /dev/mapper/loop0p1 tmp-mount/
+    [root@wakame-vdc-1box images]$ mkfs.ext4 -F -E lazy_itable_init=1 -L root /dev/mapper/loop0p1
+    [root@wakame-vdc-1box images]$ tune2fs -o acl /dev/mapper/loop0p1
+    [root@wakame-vdc-1box images]$ mkdir tmp-mount
+    [root@wakame-vdc-1box images]$ mount /dev/mapper/loop0p1 tmp-mount/
 
 Next, we copy the OpenVZ directory contents into the file system and
 then unmount the file system.
 
-    [root@wakame-vdc-1box images]# cd tmp-mount/
-    [root@wakame-vdc-1box tmp-mount]# tar xzf /vz/template/cache/new-custom-image-temp.tar.gz
-    [root@wakame-vdc-1box tmp-mount]# cd ..
-    [root@wakame-vdc-1box images]# umount tmp-mount/
-    [root@wakame-vdc-1box images]# rmdir tmp-mount/
+    [root@wakame-vdc-1box images]$ cd tmp-mount/
+    [root@wakame-vdc-1box tmp-mount]$ tar xzf /vz/template/cache/new-custom-image-temp.tar.gz
+    [root@wakame-vdc-1box tmp-mount]$ cd ..
+    [root@wakame-vdc-1box images]$ umount tmp-mount/
+    [root@wakame-vdc-1box images]$ rmdir tmp-mount/
 
 Because in some use cases disk images can have multiple partitions,
 Wakame-vdc needs to know the UUID of the formatted disk partition to
@@ -183,18 +183,18 @@ reliably identify it when booting instances.  This UUID needs to be
 found before the partition is removed from the loop device, so we
 determine it first and then release the loop device.
 
-    [root@wakame-vdc-1box images]# blkid -o export /dev/mapper/loop0p1 | tee /tmp/remember.uuid-etc
-    [root@wakame-vdc-1box images]# kpartx -vd wakame-vdc-custom-image.raw
+    [root@wakame-vdc-1box images]$ blkid -o export /dev/mapper/loop0p1 | tee /tmp/remember.uuid-etc
+    [root@wakame-vdc-1box images]$ kpartx -vd wakame-vdc-custom-image.raw
 
 Before compressing the machine image, remember its size.
 
-    [root@wakame-vdc-1box images]# ls -l wakame-vdc-custom-image.raw | awk '{print $5}' | tee /tmp/remember.size
+    [root@wakame-vdc-1box images]$ ls -l wakame-vdc-custom-image.raw | awk '{print $5}' | tee /tmp/remember.size
 
 Finally, compress the image and remember the compressed size and the checksum of the compressed machine image.
 
-    [root@wakame-vdc-1box images]# gzip wakame-vdc-custom-image.raw
-    [root@wakame-vdc-1box images]# ls -l wakame-vdc-custom-image.raw.gz | awk '{print $5}' | tee /tmp/remember.alloc_size
-    [root@wakame-vdc-1box images]# md5sum /var/lib/wakame-vdc/images/wakame-vdc-custom-image.raw.gz | head -c 32 | tee /tmp/remember.md5
+    [root@wakame-vdc-1box images]$ gzip wakame-vdc-custom-image.raw
+    [root@wakame-vdc-1box images]$ ls -l wakame-vdc-custom-image.raw.gz | awk '{print $5}' | tee /tmp/remember.alloc_size
+    [root@wakame-vdc-1box images]$ md5sum /var/lib/wakame-vdc/images/wakame-vdc-custom-image.raw.gz | head -c 32 | tee /tmp/remember.md5
 
 ### Step 5: Register this machine image file with Wakame-vdc
 

--- a/docs/content/usage/custom-machine-images.md
+++ b/docs/content/usage/custom-machine-images.md
@@ -31,14 +31,14 @@ static web page to show.  The steps for other combinations are
 similar, but differ in subtle ways that will be documented later.
 
 
-#### Step 1: Install an OS into a bootable disk or directory structure
+### Step 1: Install an OS into a bootable disk or directory structure
 
 For OpenVZ, specialized techniques are required to install an OS, so
 the recommended procedure is to use one of the *precreated templates*
 that can be found at the [OpenVZ wiki](https://wiki.openvz.org/Download/template/precreated).  Minimal
 installations of the major Linux distributions are available.
 
-#### Step 2: Specialize the OS installation for the intended purpose
+### Step 2: Specialize the OS installation for the intended purpose
 
 The most straightforward way to install and configure the installed OS
 distribution is from inside OpenVZ itself.  An environment created by
@@ -78,10 +78,10 @@ configuring software.
     [root@localhost /]# service httpd start
     [root@localhost /]# chkconfig httpd on
 
-#### Step 3: Specialize the OS installation for Wakame-vdc
+### Step 3: Specialize the OS installation for Wakame-vdc
 
 
-##### Insert the wakame-init script and run it from /etc/rc.local:
+#### Insert the wakame-init script and run it from /etc/rc.local:
 
 Note: This step is necessary so that Wakame-vdc can do last-minute
 specialization that is necessary when each instance is booted.  For
@@ -98,20 +98,20 @@ special file at `/metadata/user-data`.
 
     yum install -y wakame-init
 
-##### Clear shell history:
+#### Clear shell history:
 
 Note: This step is optional.
 
     rm /home/*/.bash_history /root/.bash_history
 
-##### Remove ssh host keys:
+#### Remove ssh host keys:
 
 Note: This step is optional but recommended so that different
 instances appear as different ssh hosts.
 
     rm /etc/ssh/ssh_host*
 
-##### Remove net rules file so eth0 doesn't become eth1 at start:
+#### Remove net rules file so eth0 doesn't become eth1 at start:
 
 Note: This step is not necessary for OpenVZ, but will not cause any
 problems.  In fact, most of the OpenVZ precreated template caches do
@@ -119,7 +119,7 @@ not have this file.
 
     rm /etc/udev/rules.d/70-persistent-net.rules
 
-#### Step 4: Package it all into one machine image file
+### Step 4: Package it all into one machine image file
 
 Exit the OpenVZ container.
 
@@ -196,7 +196,7 @@ Finally, compress the image and remember the compressed size and the checksum of
     [root@wakame-vdc-1box images]# ls -l wakame-vdc-custom-image.raw.gz | awk '{print $5}' | tee /tmp/remember.alloc_size
     [root@wakame-vdc-1box images]# md5sum /var/lib/wakame-vdc/images/wakame-vdc-custom-image.raw.gz | head -c 32 | tee /tmp/remember.md5
 
-#### Step 5: Register this machine image file with Wakame-vdc
+### Step 5: Register this machine image file with Wakame-vdc
 
 First, move the new machine image to Wakame-vdc's directory for keeping
 images.  (If the machine image was created by the above steps, it might
@@ -236,7 +236,7 @@ your are installing into an environment that was created by following
 the [Wakame-vdc install guide](../installation.md).  The correct values for
 other situations can be typed directly into the command line.
 
-### Using and testing the new image
+## Using and testing the new image
 
 It should now be possible to start an instance from the machine image
 by following the instructions in the [basic usage guide](index.md).  The only necessary modification to these instructions

--- a/docs/content/usage/custom-machine-images.md
+++ b/docs/content/usage/custom-machine-images.md
@@ -56,27 +56,33 @@ machine image is instantiated.
 
 The first few commands log into the demo VM and download a template image:
 
-    ssh centos@a.b.c.d  # where a.b.c.d is the demo VM's IP address
-    [centos@wakame-vdc-1box ~]$ sudo su
-    [root@wakame-vdc-1box centos]$ cd /vz/template/cache
-    [root@wakame-vdc-1box cache]$ wget http://download.openvz.org/template/precreated/centos-6-x86_64-minimal.tar.gz
+```bash
+ssh centos@a.b.c.d  # where a.b.c.d is the demo VM's IP address
+[centos@wakame-vdc-1box ~]$ sudo su
+[root@wakame-vdc-1box centos]$ cd /vz/template/cache
+[root@wakame-vdc-1box cache]$ wget http://download.openvz.org/template/precreated/centos-6-x86_64-minimal.tar.gz
+```
 
 Next, an OpenVZ container based on this image is started.
 Note that the 101 that appears many times below can be any number that
 is not in use by OpenVZ.
 
-    [root@wakame-vdc-1box cache]$ vzctl create 101 --ostemplate centos-6-x86_64-minimal --ipadd a.b.c.vv --hostname localhost
-    [root@wakame-vdc-1box cache]$ vzctl set 101 --nameserver 8.8.8.8 --save
-    [root@wakame-vdc-1box cache]$ vzctl start 101
+```bash
+[root@wakame-vdc-1box cache]$ vzctl create 101 --ostemplate centos-6-x86_64-minimal --ipadd a.b.c.vv --hostname localhost
+[root@wakame-vdc-1box cache]$ vzctl set 101 --nameserver 8.8.8.8 --save
+[root@wakame-vdc-1box cache]$ vzctl start 101
+```
 
 Now we can go inside the container and specialize it by installing and
 configuring software.
 
-    [root@wakame-vdc-1box cache]$ vzctl enter 101
-    [root@localhost /]$ yum install httpd
-    [root@localhost /]$ echo "<html>An Example top web page.</html>" >/var/www/html/index.html
-    [root@localhost /]$ service httpd start
-    [root@localhost /]$ chkconfig httpd on
+```bash
+[root@wakame-vdc-1box cache]$ vzctl enter 101
+[root@localhost /]$ yum install httpd
+[root@localhost /]$ echo "<html>An Example top web page.</html>" >/var/www/html/index.html
+[root@localhost /]$ service httpd start
+[root@localhost /]$ chkconfig httpd on
+```
 
 ### Step 3: Specialize the OS installation for Wakame-vdc
 
@@ -94,22 +100,28 @@ additional specialization based on
 on-the-fly while starting an instance, and scripts can read it from a
 special file at `/metadata/user-data`.
 
-    curl -o /etc/yum.repos.d/wakame-vdc.repo -R https://raw.githubusercontent.com/axsh/wakame-vdc/master/rpmbuild/wakame-vdc.repo
+```bash
+curl -o /etc/yum.repos.d/wakame-vdc.repo -R https://raw.githubusercontent.com/axsh/wakame-vdc/master/rpmbuild/wakame-vdc.repo
 
-    yum install -y wakame-init
+yum install -y wakame-init
+```
 
 #### Clear shell history:
 
 Note: This step is optional.
 
-    rm /home/*/.bash_history /root/.bash_history
+```bash
+rm /home/*/.bash_history /root/.bash_history
+```
 
 #### Remove ssh host keys:
 
 Note: This step is optional but recommended so that different
 instances appear as different ssh hosts.
 
-    rm /etc/ssh/ssh_host*
+```bash
+rm /etc/ssh/ssh_host*
+```
 
 #### Remove net rules file so eth0 doesn't become eth1 at start:
 
@@ -117,23 +129,29 @@ Note: This step is not necessary for OpenVZ, but will not cause any
 problems.  In fact, most of the OpenVZ precreated template caches do
 not have this file.
 
-    rm /etc/udev/rules.d/70-persistent-net.rules
+```bash
+rm /etc/udev/rules.d/70-persistent-net.rules
+```
 
 ### Step 4: Package it all into one machine image file
 
 Exit the OpenVZ container.
 
-    [root@localhost etc]$ exit
+```bash
+[root@localhost etc]$ exit
+```
 
 Now we are back at the demo box prompt. The following instructions are adapted from
 the [OpenVZ wiki](http://wiki.openvz.org/Updating_Ubuntu_template):
 
-    [root@wakame-vdc-1box cache]$ vzctl stop 101
-    [root@wakame-vdc-1box cache]$ vzctl set 101 --ipdel all --save
-    [root@wakame-vdc-1box cache]$ cd /vz/private/101
-    [root@wakame-vdc-1box 101]$ tar  --numeric-owner -czf /vz/template/cache/new-custom-image-temp.tar.gz .
-    [root@wakame-vdc-1box 101]$ cd ..
-    [root@wakame-vdc-1box private]$ vzctl destroy 101
+```bash
+[root@wakame-vdc-1box cache]$ vzctl stop 101
+[root@wakame-vdc-1box cache]$ vzctl set 101 --ipdel all --save
+[root@wakame-vdc-1box cache]$ cd /vz/private/101
+[root@wakame-vdc-1box 101]$ tar  --numeric-owner -czf /vz/template/cache/new-custom-image-temp.tar.gz .
+[root@wakame-vdc-1box 101]$ cd ..
+[root@wakame-vdc-1box private]$ vzctl destroy 101
+```
 
 Wakame-vdc's preferred method of packaging machine images is inside of
 partitioned VM images files. The following commands show one way to
@@ -145,8 +163,10 @@ directory and create a 10G empty image there. Other directories will
 work. The advantage of choosing this directory is so that the image
 file will already be in the right place for testing with Wakame-vdc.
 
-    [root@wakame-vdc-1box private]$ cd /var/lib/wakame-vdc/images/
-    [root@wakame-vdc-1box images]$ truncate -s 10G wakame-vdc-custom-image.raw
+```bash
+[root@wakame-vdc-1box private]$ cd /var/lib/wakame-vdc/images/
+[root@wakame-vdc-1box images]$ truncate -s 10G wakame-vdc-custom-image.raw
+```
 
 The next commands add a partition table to the image, and then make
 the first partition be an ext2 partition (i.e. which in this context,
@@ -154,28 +174,34 @@ means any Linux partition) that takes up the whole image, except
 the first 63 sectors.  The new unformatted partition is then mounted
 on a loop device.
 
-    [root@wakame-vdc-1box images]$ parted wakame-vdc-custom-image.raw mklabel msdos
-    [root@wakame-vdc-1box images]$ parted --script -- wakame-vdc-custom-image.raw mkpart primary ext2 63s -0
-    [root@wakame-vdc-1box images]$ kpartx -va wakame-vdc-custom-image.raw
+```bash
+[root@wakame-vdc-1box images]$ parted wakame-vdc-custom-image.raw mklabel msdos
+[root@wakame-vdc-1box images]$ parted --script -- wakame-vdc-custom-image.raw mkpart primary ext2 63s -0
+[root@wakame-vdc-1box images]$ kpartx -va wakame-vdc-custom-image.raw
+```
 
 Next, the mounted partition is formatted and then mounted.  Note:
 Before doing this next command, be sure the output from previous
 kpartx command says that the partition was mounted at loop0p1, and if
 not adjust the parameter accordingly.
 
-    [root@wakame-vdc-1box images]$ mkfs.ext4 -F -E lazy_itable_init=1 -L root /dev/mapper/loop0p1
-    [root@wakame-vdc-1box images]$ tune2fs -o acl /dev/mapper/loop0p1
-    [root@wakame-vdc-1box images]$ mkdir tmp-mount
-    [root@wakame-vdc-1box images]$ mount /dev/mapper/loop0p1 tmp-mount/
+```bash
+[root@wakame-vdc-1box images]$ mkfs.ext4 -F -E lazy_itable_init=1 -L root /dev/mapper/loop0p1
+[root@wakame-vdc-1box images]$ tune2fs -o acl /dev/mapper/loop0p1
+[root@wakame-vdc-1box images]$ mkdir tmp-mount
+[root@wakame-vdc-1box images]$ mount /dev/mapper/loop0p1 tmp-mount/
+```
 
 Next, we copy the OpenVZ directory contents into the file system and
 then unmount the file system.
 
-    [root@wakame-vdc-1box images]$ cd tmp-mount/
-    [root@wakame-vdc-1box tmp-mount]$ tar xzf /vz/template/cache/new-custom-image-temp.tar.gz
-    [root@wakame-vdc-1box tmp-mount]$ cd ..
-    [root@wakame-vdc-1box images]$ umount tmp-mount/
-    [root@wakame-vdc-1box images]$ rmdir tmp-mount/
+```bash
+[root@wakame-vdc-1box images]$ cd tmp-mount/
+[root@wakame-vdc-1box tmp-mount]$ tar xzf /vz/template/cache/new-custom-image-temp.tar.gz
+[root@wakame-vdc-1box tmp-mount]$ cd ..
+[root@wakame-vdc-1box images]$ umount tmp-mount/
+[root@wakame-vdc-1box images]$ rmdir tmp-mount/
+```
 
 Because in some use cases disk images can have multiple partitions,
 Wakame-vdc needs to know the UUID of the formatted disk partition to
@@ -183,18 +209,24 @@ reliably identify it when booting instances.  This UUID needs to be
 found before the partition is removed from the loop device, so we
 determine it first and then release the loop device.
 
-    [root@wakame-vdc-1box images]$ blkid -o export /dev/mapper/loop0p1 | tee /tmp/remember.uuid-etc
-    [root@wakame-vdc-1box images]$ kpartx -vd wakame-vdc-custom-image.raw
+```bash
+[root@wakame-vdc-1box images]$ blkid -o export /dev/mapper/loop0p1 | tee /tmp/remember.uuid-etc
+[root@wakame-vdc-1box images]$ kpartx -vd wakame-vdc-custom-image.raw
+```
 
 Before compressing the machine image, remember its size.
 
-    [root@wakame-vdc-1box images]$ ls -l wakame-vdc-custom-image.raw | awk '{print $5}' | tee /tmp/remember.size
+```bash
+[root@wakame-vdc-1box images]$ ls -l wakame-vdc-custom-image.raw | awk '{print $5}' | tee /tmp/remember.size
+```
 
 Finally, compress the image and remember the compressed size and the checksum of the compressed machine image.
 
-    [root@wakame-vdc-1box images]$ gzip wakame-vdc-custom-image.raw
-    [root@wakame-vdc-1box images]$ ls -l wakame-vdc-custom-image.raw.gz | awk '{print $5}' | tee /tmp/remember.alloc_size
-    [root@wakame-vdc-1box images]$ md5sum /var/lib/wakame-vdc/images/wakame-vdc-custom-image.raw.gz | head -c 32 | tee /tmp/remember.md5
+```bash
+[root@wakame-vdc-1box images]$ gzip wakame-vdc-custom-image.raw
+[root@wakame-vdc-1box images]$ ls -l wakame-vdc-custom-image.raw.gz | awk '{print $5}' | tee /tmp/remember.alloc_size
+[root@wakame-vdc-1box images]$ md5sum /var/lib/wakame-vdc/images/wakame-vdc-custom-image.raw.gz | head -c 32 | tee /tmp/remember.md5
+```
 
 ### Step 5: Register this machine image file with Wakame-vdc
 
@@ -202,7 +234,9 @@ First, move the new machine image to Wakame-vdc's directory for keeping
 images.  (If the machine image was created by the above steps, it might
 already be there.)
 
-    mv wakame-vdc-custom-image.raw.gz /var/lib/wakame-vdc/images
+```bash
+mv wakame-vdc-custom-image.raw.gz /var/lib/wakame-vdc/images
+```
 
 Registering the machine image file requires two vdc-manage commands.
 The first registers the file as a [backup object](../jargon-dictionary.md#backup-object) and assigns it to a
@@ -210,24 +244,28 @@ The first registers the file as a [backup object](../jargon-dictionary.md#backup
 register the machine image created above into [backup storage](../jargon-dictionary.md#backup-storage) named `bkst-local`, the
 following command could be used:
 
-    /opt/axsh/wakame-vdc/dcmgr/bin/vdc-manage backupobject add \
-      --uuid bo-customimage \
-      --display-name "New image with web server and one static page" \
-      --storage-id bkst-local \
-      --object-key wakame-vdc-custom-image.raw.gz \
-      --size $(cat /tmp/remember.size) \
-      --allocation-size $(cat /tmp/remember.alloc_size) \
-      --container-format gz \
-      --checksum $(cat /tmp/remember.md5)
+```bash
+/opt/axsh/wakame-vdc/dcmgr/bin/vdc-manage backupobject add \
+  --uuid bo-customimage \
+  --display-name "New image with web server and one static page" \
+  --storage-id bkst-local \
+  --object-key wakame-vdc-custom-image.raw.gz \
+  --size $(cat /tmp/remember.size) \
+  --allocation-size $(cat /tmp/remember.alloc_size) \
+  --container-format gz \
+  --checksum $(cat /tmp/remember.md5)
+```
 
 The second vdc-manage command tells Wakame-vdc that this [backup object](../jargon-dictionary.md#backup-object)
 is a machine image that we can start instances of.
 
-    /opt/axsh/wakame-vdc/dcmgr/bin/vdc-manage image add local bo-customimage \
-      --account-id a-shpoolxx \
-      --uuid wmi-customimage \
-      --root-device uuid:$(source /tmp/remember.uuid-etc ; echo $UUID) \
-      --display-name "New image with web server and one static page"
+```bash
+/opt/axsh/wakame-vdc/dcmgr/bin/vdc-manage image add local bo-customimage \
+  --account-id a-shpoolxx \
+  --uuid wmi-customimage \
+  --root-device uuid:$(source /tmp/remember.uuid-etc ; echo $UUID) \
+  --display-name "New image with web server and one static page"
+```
 
 Note that the $() expressions here supply the command with necessary
 details about the machine image, assuming it was collected as in the example


### PR DESCRIPTION
Many pages on the documentation were using different header sizes etc. I gave them all a more unified look. I also removed the table of contents on the security groups page. A table of contents feature is already implemented in the mkdocs theme we are using.