### PR TITLE
Feature mussel completion

### DIFF
--- a/client/mussel/completion/mussel-completion.bash
+++ b/client/mussel/completion/mussel-completion.bash
@@ -241,7 +241,7 @@ _mussel() {
               COMPREPLY=($(compgen -W "http https tcp ssl" -- "${cur}"))
               ;;
             --max-connection)
-              COMPREPLY=($(compgen -W "1000" -- "${cur}"))
+              COMPREPLY=($(compgen -W "1000 5000" -- "${cur}"))
               ;;
             *)
               COMPREPLY=($(compgen -W "--balance-algorithm --cookie --display-name --engine --port --instance-port --protocol --instance-protocol --max-connection" -- "${cur}"))
@@ -274,7 +274,7 @@ _mussel() {
                   COMPREPLY=($(compgen -W "http https tcp ssl" -- "${cur}"))
                   ;;
                 --max-connection)
-                  COMPREPLY=($(compgen -W "1000" -- "${cur}"))
+                  COMPREPLY=($(compgen -W "1000 5000" -- "${cur}"))
                   ;;
                 *)
                   COMPREPLY=($(compgen -W "--balance-algorithm --cookie --display-name --engine --port --instance-port --protocol --instance-protocol --max-connection" -- "${cur}"))

--- a/client/mussel/completion/mussel-completion.bash
+++ b/client/mussel/completion/mussel-completion.bash
@@ -244,7 +244,7 @@ _mussel() {
               COMPREPLY=($(compgen -W "1000" -- "${cur}"))
               ;;
             *)
-              COMPREPLY=($(compgen -W "--balance-algorithm --display-name --engine --port --instance-port --protocol --instance-protocol --max-connection" -- "${cur}"))
+              COMPREPLY=($(compgen -W "--balance-algorithm --cookie --display-name --engine --port --instance-port --protocol --instance-protocol --max-connection" -- "${cur}"))
               ;;
           esac
           ;;
@@ -277,7 +277,7 @@ _mussel() {
                   COMPREPLY=($(compgen -W "1000" -- "${cur}"))
                   ;;
                 *)
-                  COMPREPLY=($(compgen -W "--balance-algorithm --display-name --engine --port --instance-port --protocol --instance-protocol --max-connection" -- "${cur}"))
+                  COMPREPLY=($(compgen -W "--balance-algorithm --cookie --display-name --engine --port --instance-port --protocol --instance-protocol --max-connection" -- "${cur}"))
                   ;;
               esac
               ;;

--- a/client/mussel/completion/mussel-completion.bash
+++ b/client/mussel/completion/mussel-completion.bash
@@ -156,14 +156,14 @@ _mussel() {
           ;;
         create)
           case "${prev}" in
+            --cpu-cores)
+              COMPREPLY=($(compgen -W "1 2 4" -- "${cur}"))
+              ;;
             --display-name)
               COMPREPLY=($(compgen -W "" -- "${cur}"))
               ;;
             --hypervisor)
               COMPREPLY=($(compgen -W "openvz lxc kvm" -- "${cur}"))
-              ;;
-            --cpu-cores)
-              COMPREPLY=($(compgen -W "1 2 4" -- "${cur}"))
               ;;
             --image-id)
               COMPREPLY=($(compgen -W "$(mussel image index --is-public true | hash_value id)" -- "${cur}"))
@@ -181,7 +181,7 @@ _mussel() {
               COMPREPLY=($(compgen -f "${cur}"))
               ;;
             *)
-              COMPREPLY=($(compgen -W "--display-name --hypervisor --cpu-cores --image-id --memory-size --ssh-key-id --user-data --vifs" -- "${cur}"))
+              COMPREPLY=($(compgen -W "--cpu-cores --display-name --hypervisor --image-id --memory-size --ssh-key-id --user-data --vifs" -- "${cur}"))
               ;;
           esac
           ;;

--- a/client/mussel/completion/mussel-completion.bash
+++ b/client/mussel/completion/mussel-completion.bash
@@ -226,7 +226,7 @@ _mussel() {
               COMPREPLY=($(compgen -W "leastconn source" -- "${cur}"))
               ;;
             --cookie)
-              COMPREPLY=($(compgen -W "haproxy" -- "${cur}"))
+              COMPREPLY=($(compgen -W "" -- "${cur}"))
               ;;
             --display-name)
               COMPREPLY=($(compgen -W "" -- "${cur}"))
@@ -259,7 +259,7 @@ _mussel() {
                   COMPREPLY=($(compgen -W "leastconn source" -- "${cur}"))
                   ;;
                 --cookie)
-                  COMPREPLY=($(compgen -W "haproxy" -- "${cur}"))
+                  COMPREPLY=($(compgen -W "" -- "${cur}"))
                   ;;
                 --display-name)
                   COMPREPLY=($(compgen -W "" -- "${cur}"))

--- a/client/mussel/completion/mussel-completion.bash
+++ b/client/mussel/completion/mussel-completion.bash
@@ -156,6 +156,9 @@ _mussel() {
           ;;
         create)
           case "${prev}" in
+            --display-name)
+              COMPREPLY=($(compgen -W "" -- "${cur}"))
+              ;;
             --hypervisor)
               COMPREPLY=($(compgen -W "openvz lxc kvm" -- "${cur}"))
               ;;
@@ -178,7 +181,7 @@ _mussel() {
               COMPREPLY=($(compgen -f "${cur}"))
               ;;
             *)
-              COMPREPLY=($(compgen -W "--hypervisor --cpu-cores --image-id --memory-size --ssh-key-id --user-data --vifs" -- "${cur}"))
+              COMPREPLY=($(compgen -W "--display-name --hypervisor --cpu-cores --image-id --memory-size --ssh-key-id --user-data --vifs" -- "${cur}"))
               ;;
           esac
           ;;
@@ -189,11 +192,14 @@ _mussel() {
               ;;
             *)
               case "${prev}" in
+                --display-name)
+                  COMPREPLY=($(compgen -W "" -- "${cur}"))
+                  ;;
                 --ssh-key-id)
                   COMPREPLY=($(compgen -W "$(mussel ssh_key_pair index | hash_value id)" -- "${cur}"))
                   ;;
                 *)
-                  COMPREPLY=($(compgen -W "--ssh-key-id" -- "${cur}"))
+                  COMPREPLY=($(compgen -W "--display-name --ssh-key-id" -- "${cur}"))
                   ;;
               esac
               ;;
@@ -222,6 +228,9 @@ _mussel() {
             --cookie)
               COMPREPLY=($(compgen -W "haproxy" -- "${cur}"))
               ;;
+            --display-name)
+              COMPREPLY=($(compgen -W "" -- "${cur}"))
+              ;;
             --engine)
               COMPREPLY=($(compgen -W "haproxy" -- "${cur}"))
               ;;
@@ -235,7 +244,7 @@ _mussel() {
               COMPREPLY=($(compgen -W "1000" -- "${cur}"))
               ;;
             *)
-              COMPREPLY=($(compgen -W "--balance-algorithm --engine --port --instance-port --protocol --instance-protocol --max-connection" -- "${cur}"))
+              COMPREPLY=($(compgen -W "--balance-algorithm --display-name --engine --port --instance-port --protocol --instance-protocol --max-connection" -- "${cur}"))
               ;;
           esac
           ;;
@@ -252,6 +261,9 @@ _mussel() {
                 --cookie)
                   COMPREPLY=($(compgen -W "haproxy" -- "${cur}"))
                   ;;
+                --display-name)
+                  COMPREPLY=($(compgen -W "" -- "${cur}"))
+                  ;;
                 --engine)
                   COMPREPLY=($(compgen -W "haproxy" -- "${cur}"))
                   ;;
@@ -265,7 +277,7 @@ _mussel() {
                   COMPREPLY=($(compgen -W "1000" -- "${cur}"))
                   ;;
                 *)
-                  COMPREPLY=($(compgen -W "--balance-algorithm --engine --port --instance-port --protocol --instance-protocol --max-connection" -- "${cur}"))
+                  COMPREPLY=($(compgen -W "--balance-algorithm --display-name --engine --port --instance-port --protocol --instance-protocol --max-connection" -- "${cur}"))
                   ;;
               esac
               ;;
@@ -298,11 +310,14 @@ _mussel() {
           ;;
         create)
           case "${prev}" in
+            --display-name)
+              COMPREPLY=($(compgen -W "" -- "${cur}"))
+              ;;
             --rule)
               COMPREPLY=($(compgen -f "${cur}"))
               ;;
             *)
-              COMPREPLY=($(compgen -W "--rule" -- "${cur}"))
+              COMPREPLY=($(compgen -W "--display-name --rule" -- "${cur}"))
               ;;
           esac
           ;;
@@ -313,11 +328,14 @@ _mussel() {
               ;;
             *)
               case "${prev}" in
+                --display-name)
+                  COMPREPLY=($(compgen -W "" -- "${cur}"))
+                  ;;
                 --rule)
                   COMPREPLY=($(compgen -f "${cur}"))
                   ;;
                 *)
-                  COMPREPLY=($(compgen -W "--rule" -- "${cur}"))
+                  COMPREPLY=($(compgen -W "--display-name --rule" -- "${cur}"))
                   ;;
               esac
               ;;
@@ -332,11 +350,14 @@ _mussel() {
           ;;
         create)
           case "${prev}" in
+            --display-name)
+              COMPREPLY=($(compgen -W "" -- "${cur}"))
+              ;;
             --public-key)
               COMPREPLY=($(compgen -f "${cur}"))
               ;;
             *)
-              COMPREPLY=($(compgen -W "--public-key" -- "${cur}"))
+              COMPREPLY=($(compgen -W "--display-name --public-key" -- "${cur}"))
               ;;
           esac
           ;;
@@ -347,11 +368,14 @@ _mussel() {
               ;;
             *)
               case "${prev}" in
+                --display-name)
+                  COMPREPLY=($(compgen -W "" -- "${cur}"))
+                  ;;
                 --public-key)
                   COMPREPLY=($(compgen -f "${cur}"))
                   ;;
                 *)
-                  COMPREPLY=($(compgen -W "--public-key" -- "${cur}"))
+                  COMPREPLY=($(compgen -W "--display-name --public-key" -- "${cur}"))
                   ;;
               esac
               ;;


### PR DESCRIPTION
### Feature

1: This change will provide `--display-name` completion for `instance`, `load_balancer`, `security_group` and `ssh_key_pair`.

```
$ mussel instance       create [TAB]
$ mussel load_balancer  create [TAB]
$ mussel security_group create [TAB]
$ mussel ssh_key_pair   create [TAB]
```

```
$ mussel instance       update i-xxx [TAB]
$ mussel load_balancer  update lb-xxx [TAB]
$ mussel security_group update sg-xxx [TAB]
$ mussel ssh_key_pair   update ssh-xxx [TAB]
```

### Update

1: Add `--cookie` to `load_balancer` `create` / `update` completion list
2: Add `5000` to value of `--max-connection`
3: Fix `load_balancer` `--cookie` value. `haproxy` is not default value for `--cookie`.
