### PR TITLE
Fix db migration down task

### DIFF
--- a/dcmgr/config/db/migrations/0002_v1203.rb
+++ b/dcmgr/config/db/migrations/0002_v1203.rb
@@ -434,7 +434,7 @@ Sequel.migration do
 
     alter_table(:vlan_leases) do
       drop_column :dc_network_id
-      drop_index :tag_id
+      drop_index [:dc_network_id, :tag_id]
       add_index [:tag_id], :unique=>true
     end
 
@@ -449,8 +449,6 @@ Sequel.migration do
 
     alter_table(:physical_networks) do
       add_column :interface, "varchar(255)"
-      drop_column :bridge
-      drop_column :bridge_type
     end
 
     alter_table(:instances) do
@@ -498,15 +496,9 @@ Sequel.migration do
       drop_column :display_name
     end
 
-    drop_table(:backup_storages)
-
     alter_table(:job_states) do
-      drop_column :session_id
       drop_index [:session_id]
-    end
-
-    alter_table(:job_states) do
-      drop_column :command
+      drop_column :session_id
     end
 
     alter_table(:volumes) do
@@ -539,7 +531,7 @@ Sequel.migration do
       add_column :alloc_type, "int(11)", :default=>0, :null=>false
       set_column_type :description, "text"
 
-      add_index[:instance_nic_id, :network_id]
+      add_index [:instance_nic_id, :network_id]
     end
 
     alter_table(:dhcp_ranges) do

--- a/dcmgr/config/db/migrations/0002_v1203.rb
+++ b/dcmgr/config/db/migrations/0002_v1203.rb
@@ -411,6 +411,26 @@ Sequel.migration do
     drop_table(:host_node_vnets)
     drop_table(:network_services)
     drop_table(:network_vif_security_groups)
+
+    create_table(:security_group_rules) do
+      primary_key :id, :type=>"int(11)"
+      column :created_at, "datetime", :null=>false
+      column :updated_at, "datetime", :null=>false
+      column :security_group_id, "int(11)", :null=>false
+      column :permission, "varchar(255)", :null=>false
+
+      index [:security_group_id]
+    end
+
+    create_table(:instance_security_groups) do
+      primary_key :id, :type=>"int(11)"
+      column :instance_id, "int(11)", :null=>false
+      column :security_group_id, "int(11)", :null=>false
+
+      index [:instance_id]
+      index [:security_group_id]
+    end
+
     drop_table(:accounting_logs)
     drop_table(:load_balancers)
     drop_table(:load_balancer_targets)

--- a/dcmgr/config/db/migrations/0002_v1203.rb
+++ b/dcmgr/config/db/migrations/0002_v1203.rb
@@ -407,8 +407,15 @@ Sequel.migration do
   end
 
   down do
+    drop_table(:security_group_references)
     drop_table(:host_node_vnets)
     drop_table(:network_services)
+    drop_table(:network_vif_security_groups)
+    drop_table(:accounting_logs)
+    drop_table(:load_balancers)
+    drop_table(:load_balancer_targets)
+    drop_table(:backup_objects)
+    drop_table(:backup_storages)
     drop_table(:mac_ranges)
     drop_table(:network_vif_monitors)
     drop_table(:instance_monitor_attrs)

--- a/dcmgr/config/db/migrations/0005_associate_node_to_backup_storage.rb
+++ b/dcmgr/config/db/migrations/0005_associate_node_to_backup_storage.rb
@@ -9,7 +9,7 @@ Sequel.migration do
   end
 
   down do
-    drop_table(:backup_storages) do
+    alter_table(:backup_storages) do
       drop_column :node_id
     end
   end

--- a/dcmgr/config/db/migrations/0006_remove_protocol_column.rb
+++ b/dcmgr/config/db/migrations/0006_remove_protocol_column.rb
@@ -6,7 +6,7 @@ Sequel.migration do
   end
 
   down do
-    drop_table(:network_vif_monitors) do
+    alter_table(:network_vif_monitors) do
       add_column :protocol, "varchar(255)", :null=>false
     end
   end

--- a/dcmgr/config/db/migrations/0009_add_access_list_for_lb.rb
+++ b/dcmgr/config/db/migrations/0009_add_access_list_for_lb.rb
@@ -6,7 +6,7 @@ Sequel.migration do
   end
 
   down do
-    drop_table(:load_balancers) do
+    alter_table(:load_balancers) do
       drop_column :allow_list
     end
   end

--- a/dcmgr/config/db/migrations/0010_add_httpchk_path.rb
+++ b/dcmgr/config/db/migrations/0010_add_httpchk_path.rb
@@ -6,7 +6,7 @@ Sequel.migration do
   end
 
   down do
-    drop_table(:load_balancers) do
+    alter_table(:load_balancers) do
       drop_column :httpchk_path
     end
   end

--- a/dcmgr/config/db/migrations/0011_create_load_balancer_inbounds.rb
+++ b/dcmgr/config/db/migrations/0011_create_load_balancer_inbounds.rb
@@ -20,5 +20,10 @@ Sequel.migration do
 
   down do
     drop_table(:load_balancer_inbounds)
+
+    alter_table(:load_balancers) do
+      add_column :port, "int(11)", :null=>false
+      add_column :protocol, "varchar(255)", :null=>false
+    end
   end
 end

--- a/dcmgr/config/db/migrations/0012_modify_queue_finish_message.rb
+++ b/dcmgr/config/db/migrations/0012_modify_queue_finish_message.rb
@@ -9,6 +9,10 @@ Sequel.migration do
   end
 
   down do
+    alter_table(:queued_jobs) do
+      rename_column :finish_message, :failure_reason
+      set_column_type :failure_reason, "varchar(255)", :null=>true
+    end
   end
 end
 

--- a/dcmgr/config/db/migrations/0014_migrate_localstore_to_volume.rb
+++ b/dcmgr/config/db/migrations/0014_migrate_localstore_to_volume.rb
@@ -56,6 +56,36 @@ Sequel.migration do
     end
   end
 
+  down do
+    alter_table(:storage_nodes) do
+      add_column :ipaddr, "varchar(255)", :null=>false
+      add_column :transport_type, "varchar(255)", :null=>false
+    end
+
+    alter_table(:volumes) do
+      add_column :boot_dev, "int(11)", :default=>0, :null=>false
+      add_column :storage_node_id, "int(11)"
+      add_column :host_device_name, "varchar(255)"
+      add_column :transport_information, "text"
+      add_column :export_path, "varchar(255)", :null=>false
+      add_index [:storage_node_id]
+    end
+
+    #TODO <->MigrateLocalStoreToVolume.data_migrate
+
+    drop_table(:iscsi_storage_nodes)
+    drop_table(:iscsi_volumes)
+    drop_table(:local_volumes)
+
+    alter_table(:volumes) do
+      drop_column :volume_type
+    end
+
+    alter_table(:instances) do
+      drop_column :boot_volume_id
+    end
+  end
+
   module MigrateLocalStoreToVolume
     def self.data_migrate
       db = Sequel::DATABASES.first

--- a/dcmgr/config/db/migrations/0015_add_disk_entry_to_image.rb
+++ b/dcmgr/config/db/migrations/0015_add_disk_entry_to_image.rb
@@ -17,6 +17,14 @@ Sequel.migration do
   end
 
   down do
+    alter_table(:images) do
+      drop_column :volumes
+      drop_column :vifs
+    end
+
+    alter_table(:backup_objects) do
+      drop_column :source_volume_id
+    end
   end
 end
 

--- a/dcmgr/config/db/migrations/0016_add_local_storage_size.rb
+++ b/dcmgr/config/db/migrations/0016_add_local_storage_size.rb
@@ -9,6 +9,9 @@ Sequel.migration do
   end
 
   down do
+    alter_table(:host_nodes) do
+      drop_column :offering_disk_space_mb
+    end
   end
 end
 

--- a/dcmgr/config/db/migrations/0017_storage_node.rb
+++ b/dcmgr/config/db/migrations/0017_storage_node.rb
@@ -10,6 +10,9 @@ Sequel.migration do
   end
 
   down do
+    alter_table(:storage_nodes) do
+      add_column :export_path, "varchar(255)", :null=>false
+      add_column :snapshot_base_path, "varchar(255)", :null=>false
+    end
   end
 end
-

--- a/dcmgr/config/db/migrations/0018_nfs_storage_node.rb
+++ b/dcmgr/config/db/migrations/0018_nfs_storage_node.rb
@@ -14,5 +14,10 @@ Sequel.migration do
       index [:nfs_storage_node_id]
     end
   end
+
+  down do
+    drop_table(:nfs_storage_nodes)
+    drop_table(:nfs_volumes)
+  end
 end
 

--- a/dcmgr/config/db/migrations/0019_host_node_flags.rb
+++ b/dcmgr/config/db/migrations/0019_host_node_flags.rb
@@ -6,4 +6,10 @@ Sequel.migration do
       add_column :enabled, "tinyint(1)", :default=>true, :null=>false
     end
   end
+
+  down do
+    alter_table(:host_nodes) do
+      drop_column :enabled
+    end
+  end
 end

--- a/dcmgr/config/db/migrations/0021_rename_host_node_flags.rb
+++ b/dcmgr/config/db/migrations/0021_rename_host_node_flags.rb
@@ -6,4 +6,10 @@ Sequel.migration do
       rename_column :enabled, :scheduling_enabled
     end
   end
+
+  down do
+    alter_table(:host_nodes) do
+      rename_column :scheduling_enabled, :enabled
+    end
+  end
 end


### PR DESCRIPTION
### Problem

Some `down` tasks break `db:down`.

Steps to reproduce:

1. Setup latest wakame-vdc environment.
2. Setup seed data
3. `rake db:down`

```
$ cd /opt/axsh/wakame-vdc/dcmgr
$ time /opt/axsh/wakame-vdc/ruby/bin/bundle exec rake db:down
```

### TODO(not for this PR)

+ Still can't rollback data completely in `0014_migrate_localstore_to_volume.rb` after applying this change.
+ Specify schema version.
   + Current `db:down` implementation rolls back to `version=1`.
   + `rake db:migrate VERSION=xxx`
