### PR TITLE
Fix gui manage accounts association

### DIFF
--- a/frontend/dcmgr_gui/lib/cli/account.rb
+++ b/frontend/dcmgr_gui/lib/cli/account.rb
@@ -14,13 +14,13 @@ module Cli
       if options[:name] != nil && options[:name].length > 255
         raise "Account name can not be longer than 255 characters."
       end
-      
+
       fields = {:name => options[:name],:description => options[:description]}
       fields.merge!({:uuid => options[:uuid]}) unless options[:uuid].nil?
       puts super(Account,fields)
     end
-    
-    desc "show [UUID] [options]", "Show all accounts currently in the database"    
+
+    desc "show [UUID] [options]", "Show all accounts currently in the database"
     method_option :with_deleted, :type => :boolean, :default => false, :aliases => "-d", :desc => "Show deleted accounts."
     def show(uuid = nil)
       if uuid
@@ -69,7 +69,7 @@ __END
           if options[:with_deleted]
             row << (!u.deleted_at.nil?).to_s
           end
-          
+
           table << row
         }
         if table.size > 1
@@ -77,8 +77,8 @@ __END
         end
       end
     end
-    
-    desc "modify UUID [options]", "Modify an existing account."    
+
+    desc "modify UUID [options]", "Modify an existing account."
     method_option :name, :type => :string, :aliases => "-n", :desc => "The new name for the account."
     method_option :description, :type => :string, :aliases => "-d", :desc => "The new description for the account."
     def modify(uuid)
@@ -86,25 +86,25 @@ __END
       raise "Description can not be longer than 100 characters." if options[:description] != nil && options[:description].length > 100
       super(Account,uuid,{:name => options[:name],:description => options[:description]})
     end
-    
+
     #TODO: show account to confirm deletion
-    desc "del UUID [options]", "Deletes an existing account."    
+    desc "del UUID [options]", "Deletes an existing account."
     method_option :verbose, :type => :boolean, :aliases => "-v", :desc => "Print feedback on what is happening."
     def del(uuid)
       to_do = Account[uuid]
       Error.raise("Unknown frontend account UUID: #{uuid}", 100) if to_do == nil
 
       super(Account,uuid)
-      
+
       puts "Account #{uuid} has been deleted." if options[:verbose]
     end
-    
+
     desc "enable UUID [options]", "Enable an account."
     method_option :verbose, :type => :boolean, :aliases => "-v", :desc => "Print feedback on what is happening."
     def enable(uuid)
       to_enable = Account[uuid]
       Error.raise("Unknown frontend account UUID: #{uuid}", 100) if to_enable == nil
-      
+
       if to_enable.enable?
         puts "Account #{uuid} is already enabled." if options[:verbose]
       else
@@ -114,29 +114,29 @@ __END
         puts "Account #{uuid} has been enabled." if options[:verbose]
       end
     end
-    
-    desc "disable UUID [options]", "Disable an account."    
+
+    desc "disable UUID [options]", "Disable an account."
     method_option :verbose, :type => :boolean, :aliases => "-v", :desc => "Print feedback on what is happening."
     def disable(uuid)
       to_disable = Account[uuid]
       UnknownUUIDError.raise(uuid) if to_disable == nil
-      
+
       if to_disable.disable?
         puts "Account #{id} is already disabled." if options[:verbose]
       else
         to_disable.enabled = false
         to_disable.save_changes
-        
+
         puts "Account #{uuid} has been disabled." if options[:verbose]
       end
     end
-    
+
     desc "associate UUID", "Associate an account with a user or multiple users."
-    method_option :users, :type => :array, :required => true, :aliases => "-u", :desc => "The uuid of the users to associate with the account. Any non-existing uuid will be ignored"    
+    method_option :users, :type => :array, :required => true, :aliases => "-u", :desc => "The uuid of the users to associate with the account. Any non-existing uuid will be ignored"
     method_option :verbose, :type => :boolean, :aliases => "-v", :desc => "Print feedback on what is happening."
-    def associate(uuid)      
+    def associate(uuid)
       account = Account[uuid] || UnknownUUIDError.raise(uuid)
-      
+
       options[:users].each { |u|
         user = User[u]
         if user.nil?
@@ -149,18 +149,18 @@ __END
             user.primary_account_id = account.uuid
             user.save_changes
           end
-          
+
           puts "Account #{uuid} successfully associated with user #{u}." if options[:verbose]
         end
       }
     end
-    
+
     desc "dissociate UUID", "Dissociate an account from a user or multiple users."
     method_option :users, :type => :array, :required => true, :aliases => "-u", :desc => "The uuid of the users to dissociate from the account. Any non-existing or non numeral id will be ignored"
     method_option :verbose, :type => :boolean, :aliases => "-v", :desc => "Print feedback on what is happening."
     def dissociate(uuid)
       account = Account[uuid] || UnknownUUIDError.raise(uuid)
-      
+
       options[:users].each { |u|
         user = User[u]
         if user.nil?
@@ -169,9 +169,9 @@ __END
           puts "Account #{uuid} is not associated with user #{u}." if options[:verbose]
         else
           account.remove_user(user)
-          
+
           puts "Account #{uuid} successfully dissociated from user #{u}." if options[:verbose]
-          
+
           if account.uuid == user.primary_account_id
             user.primary_account_id = nil
             user.save_changes
@@ -180,10 +180,10 @@ __END
         end
       }
     end
-    
+
     class OAuthOperation < Base
       namespace :oauth
-      
+
       desc "add ACCOUNT_UUID", "Generate/Add OAuth key and secret"
       def add(account_uuid)
         account = Account[account_uuid] || UnknownUUIDError.raise(account_uuid)
@@ -223,12 +223,12 @@ __END
         end
       end
     end
-    
+
     register OAuthOperation, 'oauth', "oauth [#{OAuthOperation.tasks.keys.join(', ')}] UUID [options]", "Set/Unset quota values for the account"
 
     class QuotaOperation < Base
       namespace :quota
-      
+
       desc "set UUID TYPE VALUE", "Set quota to the account."
       def set(uuid, quota_type, quota_value)
         account = Account[uuid] || UnknownUUIDError.raise(uuid)
@@ -251,6 +251,6 @@ __END
     end
 
     register QuotaOperation, 'quota', "quota [#{QuotaOperation.tasks.keys.join(', ')}] UUID [options]", "Set/Unset quota values for the account"
-    
+
   end
 end

--- a/frontend/dcmgr_gui/lib/cli/base.rb
+++ b/frontend/dcmgr_gui/lib/cli/base.rb
@@ -13,36 +13,36 @@ module Cli
       raise ArgumentError unless options.is_a? Hash
       #TODO: Make this check a little tighter by checking that the model is either from the wakame backend or frontend
       UnknownModelError.raise(model) unless model < Sequel::Model
-      
+
       fields = options.dup
-      
+
       if fields.has_key?("uuid") || fields.has_key?(:uuid)
         fields[:uuid] = model.trim_uuid(fields[:uuid]) if model.check_uuid_format(fields[:uuid])
       end
-      
+
       #Create database fields
       new_record = model.create(fields)
-      
+
       #Return uuid if there is one
       new_record.canonical_uuid #if model.respond_to? "canonical_uuid"
     end
-    
+
     def del(model,uuid)
       UnknownModelError.raise(model) unless model < Sequel::Model
       to_delete = model[uuid] || UnknownUUIDError.raise(uuid)
       to_delete.destroy
     end
-    
+
     def modify(model,uuid,fields)
       UnknownModelError.raise(model) unless model < Sequel::Model
       raise ArgumentError unless fields.is_a? Hash
       to_modify = model[uuid] || UnknownUUIDError.raise(uuid)
-      
+
       #Use a copy of the fields hash so this method can work with frozen hashes
       fields_nonil = fields.merge({})
       #Don't update empty fields
       fields_nonil.delete_if {|key,value| value.nil?}
-      
+
       to_modify.set(fields_nonil)
       to_modify.updated_at = Time.now.utc.iso8601 if to_modify.with_timestamps?
       to_modify.save_changes

--- a/frontend/dcmgr_gui/lib/cli/errors.rb
+++ b/frontend/dcmgr_gui/lib/cli/errors.rb
@@ -16,32 +16,32 @@ module Cli
                    end)
     end
   end
-  
+
   class UnknownUUIDError < Error
     def initialize(uuid,exit_code=100)
       super("Unknown UUID: '#{uuid}'.")
     end
-    
+
     def self.raise(uuid,exit_code=100)
       super
     end
   end
-  
+
   class UnsupportedArchError < Error
     def initialize(arch,exit_code=100)
       super("Unsupported arch type: '#{arch}'.")
     end
-    
+
     def self.raise(arch,exit_code=100)
       super
     end
   end
-  
+
   class UnknownModelError < Error
     def initialize(model,exit_code=100)
       super("Not a sequel model: '#{model}'.")
     end
-    
+
     def self.raise(model,exit_code=100)
       super
     end
@@ -51,7 +51,7 @@ module Cli
     def initialize(arch,exit_code=100)
       super("Unsupported hypervisor type: '#{arch}'.")
     end
-    
+
     def self.raise(arch,exit_code=100)
       super
     end

--- a/frontend/dcmgr_gui/lib/cli/user.rb
+++ b/frontend/dcmgr_gui/lib/cli/user.rb
@@ -6,9 +6,9 @@ require 'tzinfo'
 module Cli
   class UserCli < Base
     namespace :user
-    
+
     PASSWD_TABLE='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'.split('').freeze
-    
+
     desc "add [options]", "Create a new user."
     method_option :name, :type => :string, :required => true, :aliases => "-n", :desc => "The display name for the new user." #Maximum size: 200
     method_option :uuid, :type => :string, :aliases => "-u", :desc => "The UUID for the new user."
@@ -30,13 +30,13 @@ module Cli
       else
         #Check if the primary account uuid exists
         Error.raise("Unknown Account UUID #{options[:primary_account_id]}",100) if options[:primary_account_id] != nil && Account[options[:primary_account_id]].nil?
-        
+
         #Generate password if password is null.
         passwd = options[:password] || Array.new(12) do PASSWD_TABLE[rand(PASSWD_TABLE.size)]; end.join
-        
+
         #Encrypt the password
         pwd_hash = User.encrypt_password(passwd)
-        
+
         #Put them in there
         fields = {:name => options[:name], :login_id => options[:login_id], :password => pwd_hash,
           :locale => options[:locale],
@@ -45,7 +45,7 @@ module Cli
         }
         fields.merge!({:uuid => options[:uuid]}) unless options[:uuid].nil?
         new_uuid = super(User,fields)
-        
+
         #TODO: put this in the model instead
         unless options[:primary_account_id] == nil
           new_user = User[new_uuid]
@@ -109,7 +109,7 @@ __END
           if options[:with_deleted]
             row << (!u.deleted_at.nil?).to_s
           end
-          
+
           table << row
         }
         if table.size > 1
@@ -130,26 +130,26 @@ __END
       Error.raise("User name can not be longer than 200 characters",100) if options[:name] != nil && options[:name].length > 200
       Error.raise("User login_id can not be longer than 255 characters",100) if options[:login_id] != nil && options[:login_id].length > 255
       Error.raise("User password can not be longer than 255 characters",100) if options[:password] != nil && options[:password].length > 255
-      
+
       fields = options.merge({})
       fields[:password] = User.encrypt_password(options[:password]) if options[:password]
-      
+
       super(User,uuid,fields)
     end
 
     #TODO: allow deletion of multiple id's at once
-    desc "del UUID", "Delete an existing user."    
+    desc "del UUID", "Delete an existing user."
     method_option :verbose, :type => :boolean, :aliases => "-v", :desc => "Print feedback on what is happening."
     def del(uuid)
       super(User,uuid)
       puts "User #{uuid} has been deleted." if options[:verbose]
     end
-    
+
     desc "primacc UUID", "Set or get the primary account for a user"
     method_option :account_id, :type => :string, :aliases => "-a", :desc => "The id of the new primary account"
     def primacc(uuid)
       user = User[uuid] || UnknownUUIDError.raise(uuid)
-      
+
       if options[:account_id]
         acc = Account[options[:account_id]] || UnknownUUIDError.raise(options[:account_id])
         user.primary_account_id = acc.uuid
@@ -157,11 +157,11 @@ __END
         user.add_account(acc)
       end
     end
-    
+
     desc "associate UUID", "Associate a user with one or multiple accounts."
-    method_option :account_ids, :type => :array, :required => true, :aliases => "-a", :desc => "The id of the acounts to associate these user with. Any non-existing or non numeral id will be ignored" 
+    method_option :account_ids, :type => :array, :required => true, :aliases => "-a", :desc => "The id of the acounts to associate these user with. Any non-existing or non numeral id will be ignored"
     method_option :verbose, :type => :boolean, :aliases => "-v", :desc => "Print feedback on what is happening."
-    def associate(uuid)      
+    def associate(uuid)
       user = User[uuid] || UnknownUUIDError.raise(uuid)
       options[:account_ids].each { |a|
         acc = Account[a]
@@ -179,9 +179,9 @@ __END
         end
       }
     end
-    
+
     desc "dissociate UUID", "Dissociate a user from one or multiple accounts."
-    method_option :account_ids, :type => :array, :required => true, :aliases => "-a", :desc => "The id of the acounts to dissociate these user from. Any non-existing or non numeral id will be ignored" 
+    method_option :account_ids, :type => :array, :required => true, :aliases => "-a", :desc => "The id of the acounts to dissociate these user from. Any non-existing or non numeral id will be ignored"
     method_option :verbose, :type => :boolean, :aliases => "-v", :desc => "Print feedback on what is happening."
     def dissociate(uuid)
       user = User[uuid] || UnknownUUIDError.raise(uuid)
@@ -193,9 +193,9 @@ __END
           puts "User #{uuid} is not associated with account #{a}." if options[:verbose]
         else
           user.remove_account(acc)
-          
+
           puts "User #{uuid} successfully dissociated from account #{a}." if options[:verbose]
-          
+
           if acc.canonical_uuid == user.primary_account_id
             user.primary_account_id = nil
             user.save
@@ -218,6 +218,6 @@ __END
       user.enabled = false
       user.save_changes
     end
-    
+
   end
 end

--- a/frontend/dcmgr_gui/lib/cli/user.rb
+++ b/frontend/dcmgr_gui/lib/cli/user.rb
@@ -150,9 +150,9 @@ __END
     def primacc(uuid)
       user = User[uuid] || UnknownUUIDError.raise(uuid)
 
-      if options[:account_id]
-        acc = Account[options[:account_id]] || UnknownUUIDError.raise(options[:account_id])
-        user.primary_account_id = acc.uuid
+      if acc_id = options[:account_id]
+        acc = Account[acc_id] || UnknownUUIDError.raise(acc_id)
+        user.primary_account_id = acc.canonical_uuid
         user.save
         user.add_account(acc)
       end


### PR DESCRIPTION
When investigating https://github.com/axsh/wakame-vdc/issues/583 and https://github.com/axsh/wakame-vdc/issues/495, I found another problem in the `gui-manage user primacc` command. Its account uuid syntax validation always failed.

This fixes that and cleans up dirty whitespace.

This is the only part of the diff that's not whitespace cleanup https://github.com/axsh/wakame-vdc/pull/591/files#diff-39c2c81fad44b3327ee10d49b9178c6dL152