### PR TITLE
Broken "network dhcp show"

### DIFF
--- a/dcmgr/lib/dcmgr/cli/network.rb
+++ b/dcmgr/lib/dcmgr/cli/network.rb
@@ -834,16 +834,16 @@ __END
 Network UUID:
   <%= nw.canonical_uuid %>
 Dynamic IP Address Range:
-<%- unless nw.ipv4_u32_dynamic_range_array.empty? -%>
-  <%= IPAddress::IPv4::parse_u32(nw.ipv4_u32_dynamic_range_array.shift) %> - <%= IPAddress::IPv4::parse_u32(nw.ipv4_u32_dynamic_range_array.last) %>
-<%- end -%>
+<%- nw.dhcp_range_dataset.each { |r| -%>
+  <%= IPAddress::IPv4::parse_u32(r.range_begin.to_u32) %> - <%= IPAddress::IPv4::parse_u32(r.range_end.to_u32) %>
+<%- }
 __END
       else
         cond = {}
         nw = M::Network.filter(cond).all
         print ERB.new(<<__END, nil, '-').result(binding)
 <%- nw.each { |row| -%>
-<%= row.canonical_uuid %>\t<%= IPAddress::IPv4::parse_u32(row.ipv4_u32_dynamic_range_array.shift) %>\t<%= IPAddress::IPv4::parse_u32(row.ipv4_u32_dynamic_range_array.last) %>
+<%= row.canonical_uuid %>\t<%= r.dhcp_range_dataset.count %>
 <%- } -%>
 __END
       end

--- a/dcmgr/lib/dcmgr/cli/network.rb
+++ b/dcmgr/lib/dcmgr/cli/network.rb
@@ -835,7 +835,7 @@ Network UUID:
   <%= nw.canonical_uuid %>
 Dynamic IP Address Range:
 <%- nw.dhcp_range_dataset.each { |r| -%>
-  <%= IPAddress::IPv4::parse_u32(r.range_begin.to_u32) %> - <%= IPAddress::IPv4::parse_u32(r.range_end.to_u32) %>
+  <%= r.range_begin.to_s %> - <%= r.range_end.to_s %>
 <%- }
 __END
       else


### PR DESCRIPTION
```
% vdc-manage network dhcp show 
% vdc-manage netowrk dhcp show nw-xxxx
```
They were showing incomplete information about dynamic IP address ranges in the network. User gets confusion from their broken output.

The output will be changed to show correct information as per below:

+ ``vdc-manage network dhcp show``
    It shows list of network ID and the count of assigned ranges.
+ ``vdc-manage network dhcp show nw-xxx``
    "Dynamic IP Address Range:" section shows list of IP address range begin and end.
