### PR TITLE
Fix ``vdc-manage network dhcp addrange/delrange`` Attempt 2

### DIFF
--- a/dcmgr/lib/dcmgr/models/network.rb
+++ b/dcmgr/lib/dcmgr/models/network.rb
@@ -154,47 +154,39 @@ module Dcmgr::Models
     end
 
     def add_ipv4_dynamic_range(range_begin, range_end)
-      range_begin = IPAddress::IPv4.new("#{range_begin}/#{self[:prefix]}")
-      range_end = IPAddress::IPv4.new("#{range_end}/#{self[:prefix]}")
-      test_inclusion(*validate_range_args(range_begin, range_end)) { |range, op|
-         case op
-         when :coverbegin
-           range.range_end = range_begin
-         when :coverend
-           range.range_begin = range_end
-         when :inccur
-           range.destroy
-         end
-         range.save_changes
-      }
+      # Acquire locks
+      dhcp_range_dataset.for_update.select(1).single_value
+      range_begin_u32, range_end_u32 = validate_range_args(range_begin, range_end)
 
-      self.add_dhcp_range(:range_begin=>range_begin, :range_end=>range_end)
-
-      self
+      hit_range_ds = dhcp_range_dataset.hit_ranges(range_begin_u32, range_end_u32)
+      if hit_range_ds.empty?
+        # no overwrap ranges. add new range.
+        return self.add_dhcp_range(range_begin: range_begin_u32,
+                                   range_end: range_end_u32)
+      else
+        raise "Given range includes edge overwrap to existing range"
+      end
     end
 
     def del_ipv4_dynamic_range(range_begin, range_end)
-      range_begin = IPAddress::IPv4.new("#{range_begin}/#{self[:prefix]}")
-      range_end = IPAddress::IPv4.new("#{range_end}/#{self[:prefix]}")
-      test_inclusion(*validate_range_args(range_begin, range_end)) { |range, op|
-        case op
-        when :coverbegin
-          range.range_end = range_begin
-        when :coverend
-          range.range_begin = range_end
-        when :inccur
-          range.destroy
-        when :incnew
-          t = range.range_end
-          range.range_end = range_begin
-          self.add_dhcp_range(:range_begin=>range_end, :range_end=>t)
+      # Acquire locks
+      dhcp_range_dataset.for_update.select(1).single_value
+      range_begin_u32, range_end_u32 = validate_range_args(range_begin, range_end)
+      hit_range_ds = dhcp_range_dataset.hit_ranges(range_begin_u32, range_end_u32)
+      ranges_count = hit_range_ds.count
+      if ranges_count == 1
+        r = hit_range_ds.first
+        if range_begin_u32 == r.range_begin.to_u32 &&
+            range_end_u32 == r.range_end.to_u32
+          r.destroy
+        else
+          raise "Given range does not match"
         end
-        range.save_changes
-      }
-
-      self
+      else
+        raise "Given range includes or  existing ranges (Found #{ranges_count} ranges)"
+      end
     end
-
+    
     # To check the IP address that can not be used.
     # TODO add a check of network services
     def reserved_ip?(ip)
@@ -306,50 +298,15 @@ module Dcmgr::Models
     end
 
     def validate_range_args(range_begin, range_end)
-      if range_begin.is_a?(IPAddress::IPv4)
-        raise "Different prefix length: range_begin" if range_begin.prefix != self.prefix
-      else
-        range_begin = IPAddress::IPv4.new("#{range_begin}/#{self.prefix}")
-      end
-      if range_end.is_a?(IPAddress::IPv4)
-        raise "Different prefix length: range_end" if range_end.prefix != self.prefix
-      else
-        range_end = IPAddress::IPv4.new("#{range_end}/#{self.prefix}")
-      end
+      range_begin = IPAddress::IPv4.new("#{range_begin}/#{self.prefix}")
+      range_end = IPAddress::IPv4.new("#{range_end}/#{self.prefix}")
       if !(self.ipv4_ipaddress.include?(range_begin) && self.ipv4_ipaddress.include?(range_end))
         raise "Given address range is out of the subnet: #{self.ipv4_ipaddress} #{range_begin}-#{range_end}"
       end
       if range_begin > range_end
-        t = range_begin
-        range_begin = range_end
-        range_end = t
+        raise "range_begin (#{range_begin}) is larger than range_end (#{range_end})"
       end
-      [range_begin, range_end]
-    end
-
-
-    def test_inclusion(range_begin, range_end, &blk)
-      dhcp_range_dataset.each { |r|
-        op = :outrange
-        if r.range_begin < range_begin && r.range_end > range_begin
-          # range_begin is in the range.
-          if r.range_end < range_end
-            op = :coverbegin
-          else
-            # new range is included in current range.
-            op = :incnew
-          end
-        elsif r.range_begin < range_end && r.range_end > range_end
-          # range_end is in the range.
-          if r.range_begin > range_begin
-            op = :coverend
-          end
-        elsif r.range_begin >= range_begin && r.range_end <= range_end
-          # current range is included in new range.
-          op = :inccur
-        end
-        blk.call(r, op)
-      }
+      [range_begin.to_u32, range_end.to_u32]
     end
   end
 end

--- a/dcmgr/spec/dcmgr/models/helper.rb
+++ b/dcmgr/spec/dcmgr/models/helper.rb
@@ -1,0 +1,1 @@
+require_relative "../../spec_helper"

--- a/dcmgr/spec/dcmgr/models/network_spec.rb
+++ b/dcmgr/spec/dcmgr/models/network_spec.rb
@@ -1,11 +1,58 @@
 require_relative "helper"
 
 describe Dcmgr::Models::Network do
-  context "#add_ipv4_dynamic_range" do
-    let(:network) {      Fabricate(:network, ipv4_network: "192.168.0.0") }
+  let(:network) { Fabricate(:network, ipv4_network: "192.168.0.0") }
 
+  context "#add_ipv4_dynamic_range" do
     it "works" do
-      n = network.add_ipv4_dynamic_range("192.168.0.1", "192.168.0.10")
+      network.add_ipv4_dynamic_range("192.168.0.1", "192.168.0.10")
+    end
+
+    it "works with only one address" do
+      network.add_ipv4_dynamic_range("192.168.0.1", "192.168.0.1")
+    end
+
+    it "works with non-existing ranges" do
+      network.add_ipv4_dynamic_range("192.168.0.1", "192.168.0.10")
+      network.add_ipv4_dynamic_range("192.168.0.11", "192.168.0.20")
+      network.add_ipv4_dynamic_range("192.168.0.30", "192.168.0.40")
+    end
+
+    it "fails with IPs out of network" do
+      expect {
+        network.add_ipv4_dynamic_range("172.16.0.1", "172.16.0.10")
+      }.to raise_error RuntimeError
+      expect {
+        network.add_ipv4_dynamic_range("192.168.0.1", "172.16.0.10")
+      }.to raise_error RuntimeError
+      expect {
+        network.add_ipv4_dynamic_range("172.16.0.1", "192.168.0.10")
+      }.to raise_error RuntimeError
+      expect {
+        network.add_ipv4_dynamic_range("192.168.0.0", "192.168.0.255")
+      }.to raise_error Sequel::ValidationFailed
+    end
+
+    it "fails with left high and right low range" do
+      expect {
+        network.add_ipv4_dynamic_range("192.168.0.10", "192.168.0.1")
+      }.to raise_error RuntimeError
+    end
+
+    it "fails to add overwrap range" do
+      network.add_ipv4_dynamic_range("192.168.0.1", "192.168.0.10")
+      expect {
+        network.add_ipv4_dynamic_range("192.168.0.1", "192.168.0.10")
+      }.to raise_error RuntimeError
+      expect {
+        network.add_ipv4_dynamic_range("192.168.0.1", "192.168.0.1")
+      }.to raise_error RuntimeError
+      expect {
+        network.add_ipv4_dynamic_range("192.168.0.10", "192.168.0.10")
+      }.to raise_error RuntimeError
+      expect {
+        network.add_ipv4_dynamic_range("192.168.0.5", "192.168.0.20")
+      }.to raise_error RuntimeError
     end
   end
 end

--- a/dcmgr/spec/dcmgr/models/network_spec.rb
+++ b/dcmgr/spec/dcmgr/models/network_spec.rb
@@ -1,0 +1,11 @@
+require_relative "helper"
+
+describe Dcmgr::Models::Network do
+  context "#add_ipv4_dynamic_range" do
+    let(:network) {      Fabricate(:network, ipv4_network: "192.168.0.0") }
+
+    it "works" do
+      n = network.add_ipv4_dynamic_range("192.168.0.1", "192.168.0.10")
+    end
+  end
+end

--- a/dcmgr/spec/dcmgr/models/network_spec.rb
+++ b/dcmgr/spec/dcmgr/models/network_spec.rb
@@ -55,4 +55,52 @@ describe Dcmgr::Models::Network do
       }.to raise_error RuntimeError
     end
   end
+
+  context "#del_ipv4_dynamic_range" do
+    before do
+      network.add_ipv4_dynamic_range("192.168.0.1", "192.168.0.10")
+    end
+
+    it "works" do
+      network.del_ipv4_dynamic_range("192.168.0.1", "192.168.0.10")
+    end
+
+    it "works with only one address" do
+      network.add_ipv4_dynamic_range("192.168.0.100", "192.168.0.100")
+      network.del_ipv4_dynamic_range("192.168.0.100", "192.168.0.100")
+    end
+
+    it "fails with non-existing range" do
+      expect {
+        network.del_ipv4_dynamic_range("192.168.0.100", "192.168.0.110")
+      }.to raise_error RuntimeError
+    end
+
+    it "fails with left high and right low range" do
+      expect {
+        network.del_ipv4_dynamic_range("192.168.0.10", "192.168.0.1")
+      }.to raise_error RuntimeError
+    end
+
+    it "fails with IPs out of network" do
+      expect {
+        network.del_ipv4_dynamic_range("172.16.0.1", "172.16.0.10")
+      }.to raise_error RuntimeError
+      expect {
+        network.del_ipv4_dynamic_range("192.168.0.1", "172.16.0.10")
+      }.to raise_error RuntimeError
+      expect {
+        network.del_ipv4_dynamic_range("172.16.0.1", "192.168.0.10")
+      }.to raise_error RuntimeError
+    end
+
+    it "fails with partial matching range" do
+      expect {
+        network.del_ipv4_dynamic_range("192.168.0.1", "192.168.0.5")
+      }.to raise_error RuntimeError
+      expect {
+        network.del_ipv4_dynamic_range("192.168.0.5", "192.168.0.20")
+      }.to raise_error RuntimeError
+    end
+  end
 end


### PR DESCRIPTION
Alternative implementation of #605.


The baseline for IP address range operation on this version:
- ``show`` should not have overwrap entries. this is confusable for users.
- ``addrange`` only success to non-existing range.
- ``delrange`` only success when exact match range is found.


Examples by user operations:

Add a range
```
vdc-manage network dhcp addrange nw-xxxx 192.168.0.10 192.168.0.20
```

Delete a range (192.168.0.10-20 exists)
```
vdc-manage network dhcp delrange nw-xxxx 192.168.0.10 192.168.0.20
```

Expand a range (192.168.0.10-20 exists)
```
vdc-manage network dhcp delrange nw-xxxx 192.168.0.10 192.168.0.20
vdc-manage network dhcp addrange nw-xxxx 192.168.0.10 192.168.0.30
```

Shrink a range (192.168.0.10-20 exists)
```
vdc-manage network dhcp delrange nw-xxxx 192.168.0.10 192.168.0.20
vdc-manage network dhcp addrange nw-xxxx 192.168.0.11 192.168.0.19
```
