### PR TITLE
Fix windows password set

### DIFF
--- a/dcmgr/lib/dcmgr/metadata.rb
+++ b/dcmgr/lib/dcmgr/metadata.rb
@@ -3,9 +3,7 @@
 module Dcmgr::Metadata
   I = Dcmgr::Constants::Image
 
-  # Factory method
-  def self.md_type(instance_hash, options = {})
-
+  def self.factory(instance_hash, options = {})
     # We tell instances this is their first boot by placing a file named
     # first-boot on the metadata drive.
     # This is used by for example Windows instances. They need to generate

--- a/dcmgr/lib/dcmgr/metadata.rb
+++ b/dcmgr/lib/dcmgr/metadata.rb
@@ -4,13 +4,13 @@ module Dcmgr::Metadata
   I = Dcmgr::Constants::Image
 
   # Factory method
-  def self.md_type(instance_hash)
-    os_type  = instance_hash[:image][:os_type]
-    password = instance_hash[:encrypted_password]
+  def self.md_type(instance_hash, options = {})
 
-    # Windows instances that don't have a password generated yet
-    # need to be told to generate one.
-    if os_type == I::OS_TYPE_WINDOWS && password.nil?
+    # We tell instances this is their first boot by placing a file named
+    # first-boot on the metadata drive.
+    # This is used by for example Windows instances. They need to generate
+    # the administrator password on first boot.
+    if options[:first_boot]
       AWSWithFirstBoot.new(instance_hash)
     else
       AWS.new(instance_hash)

--- a/dcmgr/lib/dcmgr/rpc/hva_handler.rb
+++ b/dcmgr/lib/dcmgr/rpc/hva_handler.rb
@@ -207,7 +207,7 @@ module Dcmgr
       end
 
       def setup_metadata_drive(options = {})
-        items = Dcmgr::Metadata.md_type(@inst, options).get_items
+        items = Dcmgr::Metadata.factory(@inst, options).get_items
 
         task_session.invoke(@hva_ctx.hypervisor_driver_class,
                             :setup_metadata_drive, [@hva_ctx, items])

--- a/dcmgr/lib/dcmgr/rpc/hva_handler.rb
+++ b/dcmgr/lib/dcmgr/rpc/hva_handler.rb
@@ -206,18 +206,14 @@ module Dcmgr
                                                                       @vol[:transport_information][:lun]]
       end
 
-      def setup_metadata_drive
-        items = get_metadata_items
+      def setup_metadata_drive(options = {})
+        items = Dcmgr::Metadata.md_type(@inst, options).get_items
 
         task_session.invoke(@hva_ctx.hypervisor_driver_class,
                             :setup_metadata_drive, [@hva_ctx, items])
 
         # export as single yaml file.
         @hva_ctx.dump_instance_parameter('metadata.yml', YAML.dump(items))
-       end
-
-      def get_metadata_items
-        Dcmgr::Metadata.md_type(@inst).get_items
       end
 
       # syntax sugar to catch any errors and continue to work the code
@@ -316,7 +312,7 @@ module Dcmgr
           next
         end
 
-        setup_metadata_drive
+        setup_metadata_drive(first_boot: true)
 
         check_interface
 
@@ -368,7 +364,7 @@ module Dcmgr
           rpc.request('sta-collector', 'update_volume', volume_id, {:state=>:attaching, :attached_at=>nil})
         end
 
-        setup_metadata_drive
+        setup_metadata_drive(first_boot: true)
 
         check_interface
         task_session.invoke(@hva_ctx.hypervisor_driver_class,


### PR DESCRIPTION
Fixes https://github.com/axsh/wakame-vdc/issues/639

This is a better solution in general since we shouldn't check whether it's the first time an instance boots by reading the password field.

This change also brings the first-boot file into Linux instances. The file will be ignored by our current Linux instances but users making custom instances could use the file if they want to.