### PR TITLE
fix unclosed erb.

### DIFF
--- a/dcmgr/lib/dcmgr/cli/network.rb
+++ b/dcmgr/lib/dcmgr/cli/network.rb
@@ -843,7 +843,7 @@ __END
         nw = M::Network.filter(cond).all
         print ERB.new(<<__END, nil, '-').result(binding)
 <%- nw.each { |row| -%>
-<%= row.canonical_uuid %>\t<%= r.dhcp_range_dataset.count %>
+<%= row.canonical_uuid %>\t<%= row.dhcp_range_dataset.count %>
 <%- } -%>
 __END
       end

--- a/dcmgr/lib/dcmgr/cli/network.rb
+++ b/dcmgr/lib/dcmgr/cli/network.rb
@@ -836,7 +836,7 @@ Network UUID:
 Dynamic IP Address Range:
 <%- nw.dhcp_range_dataset.each { |r| -%>
   <%= r.range_begin.to_s %> - <%= r.range_end.to_s %>
-<%- } %>
+<%- } -%>
 __END
       else
         cond = {}

--- a/dcmgr/lib/dcmgr/cli/network.rb
+++ b/dcmgr/lib/dcmgr/cli/network.rb
@@ -836,7 +836,7 @@ Network UUID:
 Dynamic IP Address Range:
 <%- nw.dhcp_range_dataset.each { |r| -%>
   <%= r.range_begin.to_s %> - <%= r.range_end.to_s %>
-<%- }
+<%- } %>
 __END
       else
         cond = {}

--- a/dcmgr/lib/dcmgr/cli/network.rb
+++ b/dcmgr/lib/dcmgr/cli/network.rb
@@ -843,7 +843,9 @@ __END
         nw = M::Network.filter(cond).all
         print ERB.new(<<__END, nil, '-').result(binding)
 <%- nw.each { |row| -%>
-<%= row.canonical_uuid %>\t<%= row.dhcp_range_dataset.count %>
+<%-   row.dhcp_range.each { |r| -%>
+<%=     row.canonical_uuid %>\t<%= r.range_begin.to_s %>\t<%= r.range_end.to_s %>
+<%-   } -%>
 <%- } -%>
 __END
       end

--- a/dcmgr/lib/dcmgr/cli/network.rb
+++ b/dcmgr/lib/dcmgr/cli/network.rb
@@ -843,9 +843,7 @@ __END
         nw = M::Network.filter(cond).all
         print ERB.new(<<__END, nil, '-').result(binding)
 <%- nw.each { |row| -%>
-<%-   row.dhcp_range.each { |r| -%>
-<%=     row.canonical_uuid %>\t<%= r.range_begin.to_s %>\t<%= r.range_end.to_s %>
-<%-   } -%>
+<%= row.canonical_uuid %>\t<%= row.dhcp_range_dataset.count %>
 <%- } -%>
 __END
       end

--- a/dcmgr/lib/dcmgr/cli/network.rb
+++ b/dcmgr/lib/dcmgr/cli/network.rb
@@ -834,7 +834,7 @@ __END
 Network UUID:
   <%= nw.canonical_uuid %>
 Dynamic IP Address Range:
-<%- nw.dhcp_range_dataset.each { |r| -%>
+<%- nw.dhcp_range_dataset.order_by(:range_begin).each { |r| -%>
   <%= r.range_begin.to_s %> - <%= r.range_end.to_s %>
 <%- } -%>
 __END


### PR DESCRIPTION
### Problem

Unclosed erb.

### Possible solusion

Add `%>`

### Solution report

```
$ /opt/axsh/wakame-vdc/dcmgr/bin/vdc-manage network dhcp show nw-glo
/opt/axsh/wakame-vdc/ruby/lib/ruby/2.0.0/erb.rb:849:in `eval': (erb):7: syntax error, unexpected end-of-input, expecting '}' (SyntaxError)
; _erbout.force_encoding(__ENCODING__)
                                      ^
        from /opt/axsh/wakame-vdc/ruby/lib/ruby/2.0.0/erb.rb:849:in `result'
        from /opt/axsh/wakame-vdc/dcmgr/lib/dcmgr/cli/network.rb:833:in `show'
        from /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/thor-0.18.1/lib/thor/command.rb:27:in `run'
        from /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
        from /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/thor-0.18.1/lib/thor.rb:363:in `dispatch'
        from /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/thor-0.18.1/lib/thor/invocation.rb:109:in `invoke'
        from /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/thor-0.18.1/lib/thor.rb:232:in `block in subcommand'
        from /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/thor-0.18.1/lib/thor/command.rb:27:in `run'
        from /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
        from /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/thor-0.18.1/lib/thor.rb:363:in `dispatch'
        from /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/thor-0.18.1/lib/thor/invocation.rb:109:in `invoke'
        from /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/thor-0.18.1/lib/thor.rb:232:in `block in subcommand'
        from /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/thor-0.18.1/lib/thor/command.rb:27:in `run'
        from /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
        from /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/thor-0.18.1/lib/thor.rb:363:in `dispatch'
        from /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/thor-0.18.1/lib/thor/base.rb:439:in `start'
        from /opt/axsh/wakame-vdc/dcmgr/bin/vdc-manage:171:in `block in <main>'
        from /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/sequel-3.47.0/lib/sequel/database/transactions.rb:127:in `_transaction'
        from /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/sequel-3.47.0/lib/sequel/database/transactions.rb:102:in `block in transaction'
        from /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/sequel-3.47.0/lib/sequel/database/connecting.rb:236:in `block in synchronize'
        from /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/sequel-3.47.0/lib/sequel/connection_pool/threaded.rb:104:in `hold'
        from /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/sequel-3.47.0/lib/sequel/database/connecting.rb:236:in `synchronize'
        from /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/sequel-3.47.0/lib/sequel/database/transactions.rb:95:in `transaction'
        from /opt/axsh/wakame-vdc/dcmgr/bin/vdc-manage:170:in `<main>'
```

```
$ sudo cp -pi /opt/axsh/wakame-vdc/dcmgr/lib/dcmgr/cli/network.rb /opt/axsh/wakame-vdc/dcmgr/lib/dcmgr/cli/network.rb.0
$ sudo vi /opt/axsh/wakame-vdc/dcmgr/lib/dcmgr/cli/network.rb
```

```
$ diff -u /opt/axsh/wakame-vdc/dcmgr/lib/dcmgr/cli/network.rb.0 /opt/axsh/wakame-vdc/dcmgr/lib/dcmgr/cli/network.rb
--- /opt/axsh/wakame-vdc/dcmgr/lib/dcmgr/cli/network.rb.0       2015-07-06 20:17:01.997254001 +0900
+++ /opt/axsh/wakame-vdc/dcmgr/lib/dcmgr/cli/network.rb 2015-07-06 20:21:13.993263203 +0900
@@ -836,7 +836,7 @@
 Dynamic IP Address Range:
 <%- nw.dhcp_range_dataset.each { |r| -%>
   <%= r.range_begin.to_s %> - <%= r.range_end.to_s %>
-<%- }
+<%- } %>
 __END
       else
         cond = {}
```

```
$ /opt/axsh/wakame-vdc/dcmgr/bin/vdc-manage network dhcp show nw-glo
Network UUID:
  nw-glo
Dynamic IP Address Range:
  192.0.2.53 - 192.0.2.56

```

### after fixed

#### with argument

```
$ /opt/axsh/wakame-vdc/dcmgr/bin/vdc-manage network dhcp show nw-glo
Network UUID:
  nw-glo
Dynamic IP Address Range:
  192.0.2.53 - 192.0.2.53
  192.0.2.54 - 192.0.2.54
  192.0.2.55 - 192.0.2.55
  192.0.2.56 - 192.0.2.56
```

#### without argument

```
$ /opt/axsh/wakame-vdc/dcmgr/bin/vdc-manage network dhcp show
nw-glo  4
nw-wkm  1
nw-mng  1
nw-pub  1
```
