### PR TITLE
backup-cleaner crash

### DIFF
--- a/dcmgr/bin/backup-cleaner
+++ b/dcmgr/bin/backup-cleaner
@@ -10,7 +10,7 @@ require 'fuguta'
 
 Dcmgr::Configurations.load Dcmgr::Configurations::Dcmgr
 
-Dcmgr.run_initializers
+Dcmgr.run_initializers('logger', 'sequel')
 
 require 'optparse'
 


### PR DESCRIPTION
### Problem

Step to reproduce:

```
$ /opt/axsh/wakame-vdc/dcmgr/bin/backup-cleaner --begin="2005-07-12 16:34:11" --end="2015-07-09 16:34:11" --dry-run
/opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/sequel-3.47.0/lib/sequel/model/base.rb:237:in `db': No database associated with Sequel::Model: have you called Sequel.connect or Sequel::Model.db= ? (Sequel::Error)
        from /opt/axsh/wakame-vdc/dcmgr/vendor/bundle/ruby/2.0.0/gems/sequel-3.47.0/lib/sequel/model/base.rb:382:in `inherited'
        from /opt/axsh/wakame-vdc/dcmgr/lib/dcmgr/models/base_new.rb:582:in `<module:Models>'
        from /opt/axsh/wakame-vdc/dcmgr/lib/dcmgr/models/base_new.rb:6:in `<top (required)>'
        from /opt/axsh/wakame-vdc/dcmgr/config/initializers/sequel_class_method_hook.rb:3:in `<top (required)>'
        from /opt/axsh/wakame-vdc/dcmgr/lib/dcmgr.rb:19:in `load'
        from /opt/axsh/wakame-vdc/dcmgr/lib/dcmgr.rb:19:in `block (3 levels) in <module:Dcmgr>'
        from /opt/axsh/wakame-vdc/dcmgr/lib/dcmgr.rb:18:in `glob'
        from /opt/axsh/wakame-vdc/dcmgr/lib/dcmgr.rb:18:in `block (2 levels) in <module:Dcmgr>'
        from /opt/axsh/wakame-vdc/dcmgr/lib/dcmgr.rb:16:in `each'
        from /opt/axsh/wakame-vdc/dcmgr/lib/dcmgr.rb:16:in `block in <module:Dcmgr>'
        from /opt/axsh/wakame-vdc/dcmgr/lib/dcmgr/initializer.rb:55:in `call'
        from /opt/axsh/wakame-vdc/dcmgr/lib/dcmgr/initializer.rb:55:in `block in run_initializers'
        from /opt/axsh/wakame-vdc/dcmgr/lib/dcmgr/initializer.rb:54:in `each'
        from /opt/axsh/wakame-vdc/dcmgr/lib/dcmgr/initializer.rb:54:in `run_initializers'
        from /opt/axsh/wakame-vdc/dcmgr/bin/backup-cleaner:13:in `<main>'
```

### Solution

Specify required initializer modules to `Dcmgr.run_initializers` in `backup-cleaner`.

+ `logger`
+ `sequel`
