### PR TITLE
add proper sleep to upstart system job.

### DIFF
--- a/contrib/etc/init/vdc-admin.conf
+++ b/contrib/etc/init/vdc-admin.conf
@@ -11,6 +11,10 @@ respawn limit 5 60
 env NAME=admin
 
 script
+    # If this job is failed, upstart supervisor will run again soon. It's too fast.
+    # Therefore a proper sleep is needed.
+    sleep ${SLEEP_SEC:-1}
+
     [ -f /etc/default/vdc-${NAME} ] && . /etc/default/vdc-${NAME}
     # Make RUN=yes effective only at auto start.
     [ -n "$UPSTART_EVENTS" -a "x${RUN}" != "xyes" ] && {

--- a/contrib/etc/init/vdc-auth.conf
+++ b/contrib/etc/init/vdc-auth.conf
@@ -11,6 +11,10 @@ respawn limit 5 60
 env NAME=auth
 
 script
+    # If this job is failed, upstart supervisor will run again soon. It's too fast.
+    # Therefore a proper sleep is needed.
+    sleep ${SLEEP_SEC:-1}
+
     [ -f /etc/default/vdc-${NAME} ] && . /etc/default/vdc-${NAME}
     # Make RUN=yes effective only at auto start.
     [ -n "$UPSTART_EVENTS" -a "x${RUN}" != "xyes" ] && {

--- a/contrib/etc/init/vdc-bksta.conf
+++ b/contrib/etc/init/vdc-bksta.conf
@@ -11,6 +11,10 @@ respawn limit 5 60
 env NAME=bksta
 
 script
+    # If this job is failed, upstart supervisor will run again soon. It's too fast.
+    # Therefore a proper sleep is needed.
+    sleep ${SLEEP_SEC:-1}
+
     [ -f /etc/default/vdc-${NAME} ] && . /etc/default/vdc-${NAME}
     # Make RUN=yes effective only at auto start.
     [ -n "$UPSTART_EVENTS" -a "x${RUN}" != "xyes" ] && {

--- a/contrib/etc/init/vdc-collector.conf
+++ b/contrib/etc/init/vdc-collector.conf
@@ -13,6 +13,10 @@ respawn limit 5 60
 env NAME=collector
 
 script
+    # If this job is failed, upstart supervisor will run again soon. It's too fast.
+    # Therefore a proper sleep is needed.
+    sleep ${SLEEP_SEC:-1}
+
     [ -f /etc/default/vdc-${NAME} ] && . /etc/default/vdc-${NAME}
     # Make RUN=yes effective only at auto start.
     [ -n "$UPSTART_EVENTS" -a "x${RUN}" != "xyes" ] && {

--- a/contrib/etc/init/vdc-dcmgr.conf
+++ b/contrib/etc/init/vdc-dcmgr.conf
@@ -11,6 +11,10 @@ respawn limit 5 60
 env NAME=dcmgr
 
 script
+    # If this job is failed, upstart supervisor will run again soon. It's too fast.
+    # Therefore a proper sleep is needed.
+    sleep ${SLEEP_SEC:-1}
+
     [ -f /etc/default/vdc-${NAME} ] && . /etc/default/vdc-${NAME}
     # Make RUN=yes effective only at auto start.
     [ -n "$UPSTART_EVENTS" -a "x${RUN}" != "xyes" ] && {

--- a/contrib/etc/init/vdc-dolphin.conf
+++ b/contrib/etc/init/vdc-dolphin.conf
@@ -11,6 +11,10 @@ respawn limit 5 60
 env NAME=dolphin
 
 script
+  # If this job is failed, upstart supervisor will run again soon. It's too fast.
+  # Therefore a proper sleep is needed.
+  sleep ${SLEEP_SEC:-1}
+
   [ -f /etc/default/vdc-${NAME} ] && . /etc/default/vdc-${NAME}
   # Make RUN=yes effective only at auto start.
   [ -n "$UPSTART_EVENTS" -a "x${RUN}" != "xyes" ] && {

--- a/contrib/etc/init/vdc-fluentd.conf
+++ b/contrib/etc/init/vdc-fluentd.conf
@@ -13,6 +13,10 @@ respawn limit 5 60
 env NAME=fluentd
 
 script
+    # If this job is failed, upstart supervisor will run again soon. It's too fast.
+    # Therefore a proper sleep is needed.
+    sleep ${SLEEP_SEC:-1}
+
     [ -f /etc/default/vdc-${NAME} ] && . /etc/default/vdc-${NAME}
     # Make RUN=yes effective only at auto start.
     [ -n "$UPSTART_EVENTS" -a "x${RUN}" != "xyes" ] && {

--- a/contrib/etc/init/vdc-hma.conf
+++ b/contrib/etc/init/vdc-hma.conf
@@ -11,6 +11,10 @@ respawn limit 5 60
 env NAME=hma
 
 script
+    # If this job is failed, upstart supervisor will run again soon. It's too fast.
+    # Therefore a proper sleep is needed.
+    sleep ${SLEEP_SEC:-1}
+
     [ -f /etc/default/vdc-${NAME} ] && . /etc/default/vdc-${NAME}
     # Make RUN=yes effective only at auto start.
     [ -n "$UPSTART_EVENTS" -a "x${RUN}" != "xyes" ] && {

--- a/contrib/etc/init/vdc-hva-worker.conf
+++ b/contrib/etc/init/vdc-hva-worker.conf
@@ -9,6 +9,10 @@ instance $ID
 env NAME=hva
 
 script
+    # If this job is failed, upstart supervisor will run again soon. It's too fast.
+    # Therefore a proper sleep is needed.
+    sleep ${SLEEP_SEC:-1}
+
     [ -f /etc/default/vdc-${NAME} ] && . /etc/default/vdc-${NAME}
     [ -f /etc/default/vdc-${NAME}-${ID} ] && . /etc/default/vdc-${NAME}-${ID}
 

--- a/contrib/etc/init/vdc-hva.conf
+++ b/contrib/etc/init/vdc-hva.conf
@@ -13,6 +13,10 @@ respawn limit 5 60
 env NAME=hva
 
 script
+    # If this job is failed, upstart supervisor will run again soon. It's too fast.
+    # Therefore a proper sleep is needed.
+    sleep ${SLEEP_SEC:-1}
+
     [ -f /etc/default/vdc-${NAME} ] && . /etc/default/vdc-${NAME}
     # Make RUN=yes effective only at auto start.
     [ -n "$UPSTART_EVENTS" -a "x${RUN}" != "xyes" ] && {

--- a/contrib/etc/init/vdc-metadata.conf
+++ b/contrib/etc/init/vdc-metadata.conf
@@ -11,6 +11,10 @@ respawn limit 5 60
 env NAME=metadata
 
 script
+    # If this job is failed, upstart supervisor will run again soon. It's too fast.
+    # Therefore a proper sleep is needed.
+    sleep ${SLEEP_SEC:-1}
+
     [ -f /etc/default/vdc-${NAME} ] && . /etc/default/vdc-${NAME}
     # Make RUN=yes effective only at auto start.
     [ -n "$UPSTART_EVENTS" -a "x${RUN}" != "xyes" ] && {

--- a/contrib/etc/init/vdc-natbox.conf
+++ b/contrib/etc/init/vdc-natbox.conf
@@ -13,6 +13,10 @@ respawn limit 5 60
 env NAME=natbox
 
 script
+    # If this job is failed, upstart supervisor will run again soon. It's too fast.
+    # Therefore a proper sleep is needed.
+    sleep ${SLEEP_SEC:-1}
+
     [ -f /etc/default/vdc-${NAME} ] && . /etc/default/vdc-${NAME}
     # Make RUN=yes effective only at auto start.
     [ -n "$UPSTART_EVENTS" -a "x${RUN}" != "xyes" ] && {

--- a/contrib/etc/init/vdc-nsa.conf
+++ b/contrib/etc/init/vdc-nsa.conf
@@ -11,6 +11,10 @@ respawn limit 5 60
 env NAME=nsa
 
 script
+    # If this job is failed, upstart supervisor will run again soon. It's too fast.
+    # Therefore a proper sleep is needed.
+    sleep ${SLEEP_SEC:-1}
+
     [ -f /etc/default/vdc-${NAME} ] && . /etc/default/vdc-${NAME}
     # Make RUN=yes effective only at auto start.
     [ -n "$UPSTART_EVENTS" -a "x${RUN}" != "xyes" ] && {

--- a/contrib/etc/init/vdc-nwmongw.conf
+++ b/contrib/etc/init/vdc-nwmongw.conf
@@ -11,6 +11,10 @@ respawn limit 5 60
 env NAME=nwmongw
 
 script
+    # If this job is failed, upstart supervisor will run again soon. It's too fast.
+    # Therefore a proper sleep is needed.
+    sleep ${SLEEP_SEC:-1}
+
     [ -f /etc/default/vdc-${NAME} ] && . /etc/default/vdc-${NAME}
     # Make RUN=yes effective only at auto start.
     [ -n "$UPSTART_EVENTS" -a "x${RUN}" != "xyes" ] && {

--- a/contrib/etc/init/vdc-proxy.conf
+++ b/contrib/etc/init/vdc-proxy.conf
@@ -11,6 +11,10 @@ respawn limit 5 60
 env NAME=proxy
 
 script
+    # If this job is failed, upstart supervisor will run again soon. It's too fast.
+    # Therefore a proper sleep is needed.
+    sleep ${SLEEP_SEC:-1}
+
     [ -f /etc/default/vdc-${NAME} ] && . /etc/default/vdc-${NAME}
     # Make RUN=yes effective only at auto start.
     [ -n "$UPSTART_EVENTS" -a "x${RUN}" != "xyes" ] && {

--- a/contrib/etc/init/vdc-sta.conf
+++ b/contrib/etc/init/vdc-sta.conf
@@ -11,6 +11,10 @@ respawn limit 5 60
 env NAME=sta
 
 script
+    # If this job is failed, upstart supervisor will run again soon. It's too fast.
+    # Therefore a proper sleep is needed.
+    sleep ${SLEEP_SEC:-1}
+
     [ -f /etc/default/vdc-${NAME} ] && . /etc/default/vdc-${NAME}
     # Make RUN=yes effective only at auto start.
     [ -n "$UPSTART_EVENTS" -a "x${RUN}" != "xyes" ] && {

--- a/contrib/etc/init/vdc-webui.conf
+++ b/contrib/etc/init/vdc-webui.conf
@@ -11,6 +11,10 @@ respawn limit 5 60
 env NAME=webui
 
 script
+    # If this job is failed, upstart supervisor will run again soon. It's too fast.
+    # Therefore a proper sleep is needed.
+    sleep ${SLEEP_SEC:-1}
+
     [ -f /etc/default/vdc-${NAME} ] && . /etc/default/vdc-${NAME}
     # Make RUN=yes effective only at auto start.
     [ -n "$UPSTART_EVENTS" -a "x${RUN}" != "xyes" ] && {


### PR DESCRIPTION
### Problem

When upstart system job is failed, upstart supervisor will run again soon.
Sometime this it's too fast. Too fast restarting will raech to respawn limitation soon.

### Solution

Add proper sleep to before exec not to reach respawn limitation soon.

Btw. LB instance already uses same sleep.

https://github.com/axsh/wakame-vdc/blob/develop/vmapp/load_balancer/etc/init/haproxy_updater.conf#L12-L16:

```
  # Sometimes this job failed before initializing networking with wakame-init.
  #
  # If this job is failed, upstart supervisor will run again soon. It's too fast.
  # Therefore a proper sleep is needed.
  sleep ${SLEEP_SEC:-1}
```
