### PR TITLE
hva: adapt new configuration model.

### DIFF
--- a/dcmgr/lib/dcmgr/helpers/cli_helper.rb
+++ b/dcmgr/lib/dcmgr/helpers/cli_helper.rb
@@ -245,7 +245,7 @@ module Dcmgr
                 argv.unshift(h[0])
               end
 
-              cgexec = [File.expand_path('cgexec.sh', Dcmgr.conf.script_root_path), '-g', "#{cgctx.subsystems.join(',')}:#{cgctx.scope}", '-c']
+              cgexec = [File.expand_path('cgexec.sh', Dcmgr::Configurations.hva.script_root_path), '-g', "#{cgctx.subsystems.join(',')}:#{cgctx.scope}", '-c']
               argv = cgexec + argv
             end
             super(env, *argv, options)

--- a/dcmgr/lib/dcmgr/helpers/snapshot_storage_helper.rb
+++ b/dcmgr/lib/dcmgr/helpers/snapshot_storage_helper.rb
@@ -15,7 +15,7 @@ module Dcmgr
       end
 
       def execute(cmd, args)
-        script = File.join(Dcmgr.conf.script_root_path, 'storage_service')
+        script = File.join(Dcmgr::Configurations.hva.script_root_path, 'storage_service')
         cmd = "/usr/bin/env #{@env.join(' ')} %s " + cmd
         args = [script] + args
         res = sh(cmd, args)

--- a/dcmgr/lib/dcmgr/monitor/notification.rb
+++ b/dcmgr/lib/dcmgr/monitor/notification.rb
@@ -28,7 +28,7 @@ module Dcmgr
 
         def send(value)
           raise ArgumentError unless value.is_a?(Hash)
-          DolphinClient.domain = Dcmgr.conf.dolphin_server_uri
+          DolphinClient.domain = Dcmgr::Configurations.hva.dolphin_server_uri
           DolphinClient::Event.post(value)
         end
       end

--- a/dcmgr/lib/dcmgr/node_modules/instance_monitor.rb
+++ b/dcmgr/lib/dcmgr/node_modules/instance_monitor.rb
@@ -81,7 +81,7 @@ module Dcmgr
             # missed.
             # TODO: simplify the logic below.
             if (instance[:updated_at] &&
-                (Time.now - instance[:updated_at]) > Dcmgr.conf.wait_sec_until_force_terminate_from_shuttingdown) ||
+                (Time.now - instance[:updated_at]) > Dcmgr::Configurations.hva.wait_sec_until_force_terminate_from_shuttingdown) ||
                 true
               logger.info("Force state transition for #{instance[:uuid]}: shuttingdown -> terminated")
               job.submit("hva-handle.#{@node.node_id}", "terminate", instance[:uuid], true)


### PR DESCRIPTION
This is One of #650.

### Problem

Still old configuration model.

```
          Dcmgr.conf is DEPRECATED!
          Use the new Dcmgr::Configurations methods instead. Example:
          For hva.conf:   Dcmgr::Configurations.hva
          For dcmgr.conf: Dcmgr::Configurations.dcmgr
          etc.

          Dcmgr.conf was used at:
          /opt/axsh/wakame-vdc/dcmgr/lib/dcmgr/node_modules/instance_monitor.rb:84:in `instance_state_recovery'
```

### Solution

Adapt new confugration model.
