### PR TITLE
dcmgr: adapt new configuration model.

### DIFF
--- a/dcmgr/lib/dcmgr/messaging.rb
+++ b/dcmgr/lib/dcmgr/messaging.rb
@@ -41,7 +41,7 @@ module Dcmgr
 
     def self.amqp_channel(&blk)
       if @amqp_connection.nil?
-        uri = AMQP::Client.parse_connection_uri(Dcmgr.conf.amqp_server_uri)
+        uri = AMQP::Client.parse_connection_uri(Dcmgr::Configurations.dcmgr.amqp_server_uri)
         default = ::AMQP.settings
         opts = {:host => uri['host'] || default[:host],
                 :port => uri['port'] || default[:port],


### PR DESCRIPTION
This is One of #650.

### Problem

Still old configuration model.

```
          Dcmgr.conf is DEPRECATED!
          Use the new Dcmgr::Configurations methods instead. Example:
          For hva.conf:   Dcmgr::Configurations.hva
          For dcmgr.conf: Dcmgr::Configurations.dcmgr
          etc.

          Dcmgr.conf was used at:
          /opt/axsh/wakame-vdc/dcmgr/lib/dcmgr/messaging.rb:44:in `amqp_channel'
```

### Solution

Adapt new confugration model.
