### PR TITLE
mussel: add show_password to instance.

### DIFF
--- a/client/mussel/test/component/v12.03/t.instance.sh
+++ b/client/mussel/test/component/v12.03/t.instance.sh
@@ -360,6 +360,13 @@ function test_instance_backup_volume() {
                
 }
 
+### show-password
+
+function test_instance_show_password() {
+  assertEquals "curl -X GET $(base_uri)/${namespace}s/${uuid}/password.$(suffix)" \
+               "$(cli_wrapper ${namespace} 'show_password' ${uuid})"
+}
+
 ### update
 
 function test_instance_update() {

--- a/client/mussel/test/unit/v12.03/t.instance.sh
+++ b/client/mussel/test/unit/v12.03/t.instance.sh
@@ -25,7 +25,7 @@ function setUp() {
 function test_instance_help_stderr_to_stdout_success() {
   extract_args ${namespace} help
   res=$(run_cmd  ${MUSSEL_ARGS} 2>&1)
-  assertEquals "$0 ${namespace} [help|backup|backup_volume|create|destroy|index|move|poweroff|poweron|reboot|show|show_volumes|update|xcreate]" "${res}"
+  assertEquals "$0 ${namespace} [help|backup|backup_volume|create|destroy|index|move|poweroff|poweron|reboot|show|show_password|show_volumes|update|xcreate]" "${res}"
 }
 
 ### index
@@ -144,6 +144,22 @@ function test_instance_update_uuid() {
   run_cmd ${MUSSEL_ARGS}
   assertEquals 0 $?
 }
+
+### show_password
+
+function test_instance_show_password_no_uuid() {
+  extract_args ${namespace} show_password
+  run_cmd ${MUSSEL_ARGS} 2>/dev/null
+  assertNotEquals 0 $?
+}
+
+function test_instance_show_password_uuid() {
+  extract_args ${namespace} show_password i-xxx
+  run_cmd ${MUSSEL_ARGS}
+  assertEquals 0 $?
+}
+
+## shunit2
 
 ## shunit2
 

--- a/client/mussel/v12.03.d/instance.sh
+++ b/client/mussel/v12.03.d/instance.sh
@@ -122,3 +122,12 @@ task_update() {
    ) \
    $(base_uri)/${namespace}s/${uuid}.$(suffix)
 }
+
+task_show_password() {
+  local namespace=$1 cmd=$2 uuid=$3
+  [[ -n "${namespace}" ]] || { echo "[ERROR] 'namespace' is empty (${BASH_SOURCE[0]##*/}:${LINENO})" >&2; return 1; }
+  [[ -n "${cmd}"       ]] || { echo "[ERROR] 'cmd' is empty (${BASH_SOURCE[0]##*/}:${LINENO})" >&2; return 1; }
+  [[ -n "${uuid}"      ]] || { echo "[ERROR] 'uuid' is empty (${BASH_SOURCE[0]##*/}:${LINENO})" >&2; return 1; }
+
+  call_api -X GET $(base_uri)/${namespace}s/${uuid}/password.$(suffix)
+}


### PR DESCRIPTION
### Problem

mussel does not have `instance/password` command.

### Solution

add new command as `show_password` to `instance`.

```
$ mussel instance show_password i-xxx
```
