### PR TITLE
Removed the old deprecated Dcmgr.conf method

### DIFF
--- a/dcmgr/lib/dcmgr/configurations.rb
+++ b/dcmgr/lib/dcmgr/configurations.rb
@@ -7,9 +7,6 @@ module Dcmgr
     def self.store_conf(name, conf)
       @conf ||= Hash.new { |hash, key| raise "'#{key}' was not loaded." }
       @conf[name.to_sym] = conf
-
-      # Required for the deprecated Dcmgr.conf syntax
-      @conf[:last] = conf
     end
 
     def self.load(conf_class, files = nil)
@@ -39,11 +36,6 @@ module Dcmgr
       else
         @conf.has_key?(name.to_sym)
       end
-    end
-
-    # This method's only here to support the deprecated Dcmgr.conf method
-    def self.last
-      @conf && @conf[:last]
     end
 
     # This allows us to access the configurations as if they're methods of

--- a/dcmgr/lib/dcmgr/initializer.rb
+++ b/dcmgr/lib/dcmgr/initializer.rb
@@ -8,23 +8,6 @@ module Dcmgr
     end
 
     module ClassMethods
-      def conf
-        depr_msg = %{
-          Dcmgr.conf is DEPRECATED!
-          Use the new Dcmgr::Configurations methods instead. Example:
-          For hva.conf:   Dcmgr::Configurations.hva
-          For dcmgr.conf: Dcmgr::Configurations.dcmgr
-          etc.
-
-          Dcmgr.conf was used at:
-          #{caller.first}
-        }
-
-        puts(depr_msg)
-
-        Dcmgr::Configurations.last
-      end
-
       def load_conf(conf_class, files = nil)
         depr_msg = %{
           Dcmgr.load_conf is DEPRECATED!


### PR DESCRIPTION
The last step of https://github.com/axsh/wakame-vdc/issues/650. Now that all references to the old configuration style have been removed, we can also remove the deprecated method.