### PR TITLE
Version bump to 1.0

### DIFF
--- a/dcmgr/lib/dcmgr/version.rb
+++ b/dcmgr/lib/dcmgr/version.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 module Dcmgr
-  VERSION_MAJOR="15.03"
+  VERSION_MAJOR=1
   VERSION_MINOR=0
 
   VERSION="#{VERSION_MAJOR}.#{VERSION_MINOR}"

--- a/rpmbuild/README.md
+++ b/rpmbuild/README.md
@@ -33,8 +33,8 @@ Developing Wakame-VDC RPMs
 
     $ [ -d ~/rpmbuild/BUILD/ ] || mkdir -p ~/rpmbuild/BUILD/
     $ cd ~/rpmbuild/BUILD/
-    $ git clone git://github.com/axsh/wakame-vdc.git wakame-vdc-15.03
-    $ cd wakame-vdc-15.03
+    $ git clone git://github.com/axsh/wakame-vdc.git wakame-vdc-1.0
+    $ cd wakame-vdc-1.0
 
 ### Modifying files.
 

--- a/rpmbuild/SPECS/wakame-init.spec
+++ b/rpmbuild/SPECS/wakame-init.spec
@@ -7,7 +7,7 @@
 # --define "build_id $(../helpers/gen-release-id.sh [ commit-hash ])"
 # --define "repo_uri git://github.com/axsh/wakame-vdc.git"
 
-%define version_id 15.03
+%define version_id 1.0
 %define release_id 1.daily
 %{?version_tag:%define version_id %{version_tag}}
 %{?build_id:%define release_id %{build_id}}

--- a/rpmbuild/SPECS/wakame-vdc-example-1box.spec
+++ b/rpmbuild/SPECS/wakame-vdc-example-1box.spec
@@ -9,7 +9,7 @@
 # --define "build_id $(../helpers/gen-release-id.sh [ commit-hash ])"
 # --define "repo_uri git://github.com/axsh/wakame-vdc.git"
 
-%define version_id 15.03
+%define version_id 1.0
 %define release_id 1.daily
 %{?version_tag:%define version_id %{version_tag}}
 %{?build_id:%define release_id %{build_id}}

--- a/rpmbuild/SPECS/wakame-vdc.spec
+++ b/rpmbuild/SPECS/wakame-vdc.spec
@@ -8,7 +8,7 @@
 # --define "build_id $(../helpers/gen-release-id.sh [ commit-hash ])"
 # --define "repo_uri git://github.com/axsh/wakame-vdc.git"
 
-%define version_id 15.03
+%define version_id 1.0
 %define release_id 1.daily
 %{?version_tag:%define version_id %{version_tag}}
 %{?build_id:%define release_id %{build_id}}

--- a/wakame-init/README.md
+++ b/wakame-init/README.md
@@ -42,11 +42,11 @@ created package
 ```
 $ ls -la ../ | grep wakame-init_*
 drwxrwxr-x  5 vagrant vagrant 4096 Mar 13 10:31 wakame-init
--rw-r--r--  1 vagrant vagrant 4580 Mar 13 10:32 wakame-init_15.03-1_all.deb
--rw-r--r--  1 vagrant vagrant 4707 Mar 13 10:32 wakame-init_15.03-1_amd64.build
--rw-r--r--  1 vagrant vagrant 1154 Mar 13 10:32 wakame-init_15.03-1_amd64.changes
--rw-r--r--  1 vagrant vagrant  515 Mar 13 10:31 wakame-init_15.03-1.dsc
--rw-r--r--  1 vagrant vagrant 5594 Mar 13 10:31 wakame-init_15.03-1.tar.gz
+-rw-r--r--  1 vagrant vagrant 4580 Mar 13 10:32 wakame-init_1.0-1_all.deb
+-rw-r--r--  1 vagrant vagrant 4707 Mar 13 10:32 wakame-init_1.0-1_amd64.build
+-rw-r--r--  1 vagrant vagrant 1154 Mar 13 10:32 wakame-init_1.0-1_amd64.changes
+-rw-r--r--  1 vagrant vagrant  515 Mar 13 10:31 wakame-init_1.0-1.dsc
+-rw-r--r--  1 vagrant vagrant 5594 Mar 13 10:31 wakame-init_1.0-1.tar.gz
 
 ```
 

--- a/wakame-init/debian/changelog
+++ b/wakame-init/debian/changelog
@@ -1,3 +1,9 @@
+wakame-init (1.0-1) unstable; urgency=low
+
+  * Bump version
+
+ -- Axsh Co. LTD <dev@axsh.net>  Tue, 28 Jul 2015 14:48:00 +0900
+
 wakame-init (15.03-1) unstable; urgency=low
 
   * Bump version


### PR DESCRIPTION
I don't think this version constant is used anywhere so I'd nominate it for removal in the future. For now though, I'm bumping it to `1.0`.