### PR TITLE
Use 15.4 instead of 1.0 for the next version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@
 All notable changes to Wakame-vdc will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [1.0] - 2015-07-31
+## [15.4] - 2015-07-31
 
 `Changed` Adopted Semantic Versioning.
 
-Before this version, Wakame-vdc was constantly releasing every time we merged code while sometimes assigning a version number based on the current date. Since version numbers based on date don't conform to semantic versioning, we have decided to drop that format.
+Before this version, Wakame-vdc was constantly releasing every time we merged code while sometimes assigning a version number based on the current date. Since version numbers based on date don't conform to semantic versioning, we have decided to drop that format. The new format will be: `Major version`.`Minor version`.`Hotfix`
 
 From now on we will release stable versions every few months while keeping track of the changes in this file.
 

--- a/dcmgr/lib/dcmgr/version.rb
+++ b/dcmgr/lib/dcmgr/version.rb
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
 module Dcmgr
-  VERSION_MAJOR=1
-  VERSION_MINOR=0
+  VERSION_MAJOR=15
+  VERSION_MINOR=4
 
   VERSION="#{VERSION_MAJOR}.#{VERSION_MINOR}"
 end

--- a/rpmbuild/README.md
+++ b/rpmbuild/README.md
@@ -33,8 +33,8 @@ Developing Wakame-VDC RPMs
 
     $ [ -d ~/rpmbuild/BUILD/ ] || mkdir -p ~/rpmbuild/BUILD/
     $ cd ~/rpmbuild/BUILD/
-    $ git clone git://github.com/axsh/wakame-vdc.git wakame-vdc-1.0
-    $ cd wakame-vdc-1.0
+    $ git clone git://github.com/axsh/wakame-vdc.git wakame-vdc-15.4
+    $ cd wakame-vdc-15.4
 
 ### Modifying files.
 

--- a/rpmbuild/SPECS/wakame-init.spec
+++ b/rpmbuild/SPECS/wakame-init.spec
@@ -7,7 +7,7 @@
 # --define "build_id $(../helpers/gen-release-id.sh [ commit-hash ])"
 # --define "repo_uri git://github.com/axsh/wakame-vdc.git"
 
-%define version_id 1.0
+%define version_id 15.4
 %define release_id 1.daily
 %{?version_tag:%define version_id %{version_tag}}
 %{?build_id:%define release_id %{build_id}}

--- a/rpmbuild/SPECS/wakame-vdc-example-1box.spec
+++ b/rpmbuild/SPECS/wakame-vdc-example-1box.spec
@@ -9,7 +9,7 @@
 # --define "build_id $(../helpers/gen-release-id.sh [ commit-hash ])"
 # --define "repo_uri git://github.com/axsh/wakame-vdc.git"
 
-%define version_id 1.0
+%define version_id 15.4
 %define release_id 1.daily
 %{?version_tag:%define version_id %{version_tag}}
 %{?build_id:%define release_id %{build_id}}

--- a/rpmbuild/SPECS/wakame-vdc.spec
+++ b/rpmbuild/SPECS/wakame-vdc.spec
@@ -8,7 +8,7 @@
 # --define "build_id $(../helpers/gen-release-id.sh [ commit-hash ])"
 # --define "repo_uri git://github.com/axsh/wakame-vdc.git"
 
-%define version_id 1.0
+%define version_id 15.4
 %define release_id 1.daily
 %{?version_tag:%define version_id %{version_tag}}
 %{?build_id:%define release_id %{build_id}}

--- a/wakame-init/README.md
+++ b/wakame-init/README.md
@@ -42,11 +42,11 @@ created package
 ```
 $ ls -la ../ | grep wakame-init_*
 drwxrwxr-x  5 vagrant vagrant 4096 Mar 13 10:31 wakame-init
--rw-r--r--  1 vagrant vagrant 4580 Mar 13 10:32 wakame-init_1.0-1_all.deb
--rw-r--r--  1 vagrant vagrant 4707 Mar 13 10:32 wakame-init_1.0-1_amd64.build
--rw-r--r--  1 vagrant vagrant 1154 Mar 13 10:32 wakame-init_1.0-1_amd64.changes
--rw-r--r--  1 vagrant vagrant  515 Mar 13 10:31 wakame-init_1.0-1.dsc
--rw-r--r--  1 vagrant vagrant 5594 Mar 13 10:31 wakame-init_1.0-1.tar.gz
+-rw-r--r--  1 vagrant vagrant 4580 Mar 13 10:32 wakame-init_15.4-1_all.deb
+-rw-r--r--  1 vagrant vagrant 4707 Mar 13 10:32 wakame-init_15.4-1_amd64.build
+-rw-r--r--  1 vagrant vagrant 1154 Mar 13 10:32 wakame-init_15.4-1_amd64.changes
+-rw-r--r--  1 vagrant vagrant  515 Mar 13 10:31 wakame-init_15.4-1.dsc
+-rw-r--r--  1 vagrant vagrant 5594 Mar 13 10:31 wakame-init_15.4-1.tar.gz
 
 ```
 

--- a/wakame-init/debian/changelog
+++ b/wakame-init/debian/changelog
@@ -1,4 +1,4 @@
-wakame-init (1.0-1) unstable; urgency=low
+wakame-init (15.4-1) unstable; urgency=low
 
   * Bump version
 


### PR DESCRIPTION
Changes the next version of Wakame-vdc to `15.4`.

Going from version 15.03 to 1.0 would break the upgrade path. Yum would think 1.0 is lower than 15.03 and we could no longer do `yum update`.

We are still moving to [semantic versioning](http://semver.org) and therefore the next version if 15.4 and not 15.07.

From now on the versioning scheme will be: `Major version`.`Minor version`.`Hotfix`