### PR TITLE
Bumped the version to 16.0 instead of 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to Wakame-vdc will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [1.0] - 2015-07-31
+## [16.0] - 2015-07-31
 
 `Changed` Adopted Semantic Versioning.
 

--- a/dcmgr/lib/dcmgr/version.rb
+++ b/dcmgr/lib/dcmgr/version.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 module Dcmgr
-  VERSION_MAJOR=1
+  VERSION_MAJOR=16
   VERSION_MINOR=0
 
   VERSION="#{VERSION_MAJOR}.#{VERSION_MINOR}"

--- a/rpmbuild/README.md
+++ b/rpmbuild/README.md
@@ -33,8 +33,8 @@ Developing Wakame-VDC RPMs
 
     $ [ -d ~/rpmbuild/BUILD/ ] || mkdir -p ~/rpmbuild/BUILD/
     $ cd ~/rpmbuild/BUILD/
-    $ git clone git://github.com/axsh/wakame-vdc.git wakame-vdc-1.0
-    $ cd wakame-vdc-1.0
+    $ git clone git://github.com/axsh/wakame-vdc.git wakame-vdc-16.0
+    $ cd wakame-vdc-16.0
 
 ### Modifying files.
 

--- a/rpmbuild/SPECS/wakame-init.spec
+++ b/rpmbuild/SPECS/wakame-init.spec
@@ -7,7 +7,7 @@
 # --define "build_id $(../helpers/gen-release-id.sh [ commit-hash ])"
 # --define "repo_uri git://github.com/axsh/wakame-vdc.git"
 
-%define version_id 1.0
+%define version_id 16.0
 %define release_id 1.daily
 %{?version_tag:%define version_id %{version_tag}}
 %{?build_id:%define release_id %{build_id}}

--- a/rpmbuild/SPECS/wakame-vdc-example-1box.spec
+++ b/rpmbuild/SPECS/wakame-vdc-example-1box.spec
@@ -9,7 +9,7 @@
 # --define "build_id $(../helpers/gen-release-id.sh [ commit-hash ])"
 # --define "repo_uri git://github.com/axsh/wakame-vdc.git"
 
-%define version_id 1.0
+%define version_id 16.0
 %define release_id 1.daily
 %{?version_tag:%define version_id %{version_tag}}
 %{?build_id:%define release_id %{build_id}}

--- a/rpmbuild/SPECS/wakame-vdc.spec
+++ b/rpmbuild/SPECS/wakame-vdc.spec
@@ -8,7 +8,7 @@
 # --define "build_id $(../helpers/gen-release-id.sh [ commit-hash ])"
 # --define "repo_uri git://github.com/axsh/wakame-vdc.git"
 
-%define version_id 1.0
+%define version_id 16.0
 %define release_id 1.daily
 %{?version_tag:%define version_id %{version_tag}}
 %{?build_id:%define release_id %{build_id}}

--- a/wakame-init/README.md
+++ b/wakame-init/README.md
@@ -42,11 +42,11 @@ created package
 ```
 $ ls -la ../ | grep wakame-init_*
 drwxrwxr-x  5 vagrant vagrant 4096 Mar 13 10:31 wakame-init
--rw-r--r--  1 vagrant vagrant 4580 Mar 13 10:32 wakame-init_1.0-1_all.deb
--rw-r--r--  1 vagrant vagrant 4707 Mar 13 10:32 wakame-init_1.0-1_amd64.build
--rw-r--r--  1 vagrant vagrant 1154 Mar 13 10:32 wakame-init_1.0-1_amd64.changes
--rw-r--r--  1 vagrant vagrant  515 Mar 13 10:31 wakame-init_1.0-1.dsc
--rw-r--r--  1 vagrant vagrant 5594 Mar 13 10:31 wakame-init_1.0-1.tar.gz
+-rw-r--r--  1 vagrant vagrant 4580 Mar 13 10:32 wakame-init_16.0-1_all.deb
+-rw-r--r--  1 vagrant vagrant 4707 Mar 13 10:32 wakame-init_16.0-1_amd64.build
+-rw-r--r--  1 vagrant vagrant 1154 Mar 13 10:32 wakame-init_16.0-1_amd64.changes
+-rw-r--r--  1 vagrant vagrant  515 Mar 13 10:31 wakame-init_16.0-1.dsc
+-rw-r--r--  1 vagrant vagrant 5594 Mar 13 10:31 wakame-init_16.0-1.tar.gz
 
 ```
 

--- a/wakame-init/debian/changelog
+++ b/wakame-init/debian/changelog
@@ -1,4 +1,4 @@
-wakame-init (1.0-1) unstable; urgency=low
+wakame-init (16.0-1) unstable; urgency=low
 
   * Bump version
 


### PR DESCRIPTION
This way we can do a `yum update`. The 16 makes it more clear that this is a new version and from now on we'll be doing semantic versioning.