### PR TITLE
Mussel rdp testing

### DIFF
--- a/client/mussel/test/acceptance/v12.03/helper_shunit2.sh
+++ b/client/mussel/test/acceptance/v12.03/helper_shunit2.sh
@@ -19,6 +19,7 @@ readonly shunit2_file=${BASH_SOURCE[0]%/*}/../../shunit2
 . ${BASH_SOURCE[0]%/*}/../../helpers/ssl.sh
 . ${BASH_SOURCE[0]%/*}/../../helpers/interactive.sh
 . ${BASH_SOURCE[0]%/*}/../../helpers/alarm.sh
+. ${BASH_SOURCE[0]%/*}/../../helpers/rdp.sh
 
 ## environment-specific configuration
 

--- a/client/mussel/test/acceptance/v12.03/windows-instance/Makefile
+++ b/client/mussel/test/acceptance/v12.03/windows-instance/Makefile
@@ -1,0 +1,4 @@
+all: test
+
+test:
+	for i in ./t.*; do echo "Running $$i"; $$i || exit; done

--- a/client/mussel/test/acceptance/v12.03/windows-instance/helper_instance.sh
+++ b/client/mussel/test/acceptance/v12.03/windows-instance/helper_instance.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# requires:
+#   bash
+#
+
+## include files
+
+## variables
+
+declare instance_ipaddr=
+
+function needs_vif() { true; }
+function needs_secg() { true; }
+
+# image_id= [ wmi-windows2008r2 | wmi-windows2012r2 ]
+vifs_eth0_network_id=${vifs_eth0_network_id:-nw-demo1}
+cpu_cores=1
+memory_size=1024
+retry_wait_sec_for_windows_boot="${retry_wait_sec_for_windows_boot:-"$((60 * 10))"}"
+
+## functions
+
+### instance
+
+function render_vif_table() {
+  cat <<-EOS
+	{"eth0":{"index":"0","network":"${vifs_eth0_network_id}","security_groups":"${security_group_uuid}"}}
+	EOS
+}
+
+### shunit2 setup
+
+function oneTimeSetUp() {
+  OLD_RETRY_WAIT_SEC=${RETRY_WAIT_SEC}
+  export RETRY_WAIT_SEC="${retry_wait_sec_for_windows_boot}"
+
+  create_instance
+
+  export RETRY_WAIT_SEC=${OLD_RETRY_WAIT_SEC}
+  export OLD_RETRY_WAIT_SEC=
+}
+
+function oneTimeTearDown() {
+  destroy_instance
+}

--- a/client/mussel/test/acceptance/v12.03/windows-instance/helper_shunit2.sh
+++ b/client/mussel/test/acceptance/v12.03/windows-instance/helper_shunit2.sh
@@ -1,0 +1,15 @@
+# -*-Shell-script-*-
+#
+# requires:
+#   bash
+#
+
+## system variables
+
+## include files
+
+. ${BASH_SOURCE[0]%/*}/../helper_shunit2.sh
+
+## group variables
+
+## group functions

--- a/client/mussel/test/acceptance/v12.03/windows-instance/t.instance.base.sh
+++ b/client/mussel/test/acceptance/v12.03/windows-instance/t.instance.base.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# requires:
+#  bash
+#
+
+## include files
+
+. ${BASH_SOURCE[0]%/*}/helper_shunit2.sh
+. ${BASH_SOURCE[0]%/*}/helper_instance.sh
+
+## variables
+
+rdp_user="${rdp_user:-"Administrator"}"
+
+## functions
+
+function render_secg_rule() {
+  cat <<-EOS
+	icmp:-1,-1,ip4:0.0.0.0/0
+	tcp:3389,3389,ip4:0.0.0.0/0
+	EOS
+}
+
+### step
+
+function test_get_instance_ipaddr() {
+  instance_ipaddr=$(run_cmd instance show ${instance_uuid} | hash_value address)
+  assertEquals 0 $?
+}
+
+function test_wait_for_network_to_be_ready() {
+  wait_for_network_to_be_ready ${instance_ipaddr}
+  assertEquals 0 $?
+}
+
+function test_wait_for_rdpd_to_be_ready() {
+  wait_for_rdpd_to_be_ready ${instance_ipaddr}
+  assertEquals 0 $?
+}
+
+## shunit2
+
+. ${shunit2_file}

--- a/client/mussel/test/acceptance/v12.03/windows-instance/t.instance.base.sh
+++ b/client/mussel/test/acceptance/v12.03/windows-instance/t.instance.base.sh
@@ -25,7 +25,7 @@ function render_secg_rule() {
 ### step
 
 function test_get_instance_ipaddr() {
-  instance_ipaddr=$(run_cmd instance show ${instance_uuid} | hash_value address)
+  instance_ipaddr="$(run_cmd instance show ${instance_uuid} | hash_value address)"
   assertEquals 0 $?
 }
 
@@ -36,6 +36,44 @@ function test_wait_for_network_to_be_ready() {
 
 function test_wait_for_rdpd_to_be_ready() {
   wait_for_rdpd_to_be_ready ${instance_ipaddr}
+  assertEquals 0 $?
+}
+
+function test_rdp_auth() {
+  # 1: GET instance/password
+  instance_password="$(run_cmd instance show_password ${instance_uuid})"
+  assertEquals 0 $?
+
+  echo "${instance_password}"
+  # ---
+  # :id: i-czulsyoj
+  # :encrypted_password: |
+  #  IAAMQn+4axLf/EO+dzQWhzDOBY/dkOCvDegiL8eS1VTs9MrwgA05vnCQ//EO
+  #  RaZPfWQLV4qhIjr1h4RUNQZ41Hs22lOztb2qpACuQzlfXpTKDp3YhZdOw/V8
+  #  hencQ02g8uziV5+Wpy1DLikkATMrRLurp2zsg7XQp/0mO9e16YzkzO9Xor3R
+  #  C+daGS/YeB8BZqQbwZgzWLnrgRm7q6zzKJoGxl67+RYHki/19n1gFQXNVyOi
+  #  /gZo1sdAPF/N2a18naOM4lpbjRr4R2u82mkgCMFYzRJew9yvOTGkFhwZamkX
+  #  9j+wU5Cvo0fDDpS4pXlRTvbmu9ESTmg0tSfFyuCgkA==
+
+  # 2: get encrypted_password value
+  instance_password="$(echo "${instance_password}" | egrep '^  ' | sed 's,^  ,,')"
+  [[ -n "${instance_password}" ]]
+  assertEquals 0 $?
+
+  # 3: private key exists?
+  [[ -f "${ssh_key_pair_path}" ]]
+  assertEquals 0 $?
+
+  # 4: decrypt password
+  echo "ssh_key_pair_path: ${ssh_key_pair_path}"
+  cat "${ssh_key_pair_path}"
+  plain_password="$(echo "${instance_password}" | base64 --decode | openssl rsautl -decrypt -inkey "${ssh_key_pair_path}" -oaep)"
+  [[ -n "${plain_password}" ]]
+
+  echo "plain_password:${plain_password}"
+
+  # 5: rdp auth
+  rdp_auth -u "${rdp_user}" -p "${plain_password}" "${instance_ipaddr}"
   assertEquals 0 $?
 }
 

--- a/client/mussel/test/acceptance/v12.03/windows-instance/t.instance.base.sh
+++ b/client/mussel/test/acceptance/v12.03/windows-instance/t.instance.base.sh
@@ -65,12 +65,12 @@ function test_rdp_auth() {
   assertEquals 0 $?
 
   # 4: decrypt password
-  echo "ssh_key_pair_path: ${ssh_key_pair_path}"
+  echo "ssh_key_pair_path='${ssh_key_pair_path}'"
   cat "${ssh_key_pair_path}"
   plain_password="$(echo "${instance_password}" | base64 --decode | openssl rsautl -decrypt -inkey "${ssh_key_pair_path}" -oaep)"
   [[ -n "${plain_password}" ]]
 
-  echo "plain_password:${plain_password}"
+  echo "plain_password='${plain_password}'"
 
   # 5: rdp auth
   rdp_auth -u "${rdp_user}" -p "${plain_password}" "${instance_ipaddr}"

--- a/client/mussel/test/helpers/rdp.sh
+++ b/client/mussel/test/helpers/rdp.sh
@@ -2,6 +2,7 @@
 #
 # requires:
 #   bash
+#   rm, ln, xfreerdp
 #
 
 function xfreerdp() {

--- a/client/mussel/test/helpers/rdp.sh
+++ b/client/mussel/test/helpers/rdp.sh
@@ -1,0 +1,25 @@
+# -*-Shell-script-*-
+#
+# requires:
+#   bash
+#
+
+function xfreerdp() {
+  type -P xfreerdp >/dev/null || return 1
+
+  ignore_freerdp_local_database
+  "$(type -P xfreerdp)" --ignore-certificate "${@}"
+}
+
+function ignore_freerdp_local_database() {
+  rm   -rf ${HOME}/.freerdp
+  ln -fs /dev/null ${HOME}/.freerdp
+}
+
+function rdp_auth() {
+  xfreerdp --authonly "${@}" >/dev/null 2>&1
+}
+
+function rdp_connect() {
+  xfreerdp "${@}"
+}

--- a/client/mussel/test/helpers/retry.sh
+++ b/client/mussel/test/helpers/retry.sh
@@ -78,6 +78,11 @@ function wait_for_httpd_to_be_ready() {
   wait_for_port_to_be_ready ${ipaddr} tcp 80
 }
 
+function wait_for_rdpd_to_be_ready() {
+  local ipaddr=$1
+  wait_for_port_to_be_ready ${ipaddr} tcp 3389
+}
+
 ## wait for *not to be*
 
 function wait_for_network_not_to_be_ready() {
@@ -98,4 +103,9 @@ function wait_for_sshd_not_to_be_ready() {
 function wait_for_httpd_not_to_be_ready() {
   local ipaddr=$1
   wait_for_port_not_to_be_ready ${ipaddr} tcp 80
+}
+
+function wait_for_rdpd_not_to_be_ready() {
+  local ipaddr=$1
+  wait_for_port_not_to_be_ready ${ipaddr} tcp 3389
 }


### PR DESCRIPTION
### Features

RDP Auth testing for windows instance.

1. Create a windows instance
2. RDP login to the instance

### System Requirement

+ `xfreerdp`

### Usage

`wmi-windows2008r2` should exist.

```
$ cd client/mussel/test/acceptance/v12.03/windows-instance
$ image_id=wmi-windows2008r2 ./t.instance.base.sh
```
