### PR TITLE
Fix scheduler database sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 `Fixed` A critical bug in the *PipedRules* host node scheduler that caused it to crash when used.
 
+`Fixed` A minor race condition that could some times cause an unexpected (but still valid) IP address to be assigned when scheduling new instances.
+
 ## [16.0] - 2015-07-31
 
 `Changed` Adopted Semantic Versioning.

--- a/dcmgr/lib/dcmgr/scheduler/ip_address/incremental.rb
+++ b/dcmgr/lib/dcmgr/scheduler/ip_address/incremental.rb
@@ -26,7 +26,7 @@ module Dcmgr::Scheduler::IPAddress
       network = options[:network]
       ip_lease_alives = network.network_vif_ip_lease_dataset.alives
 
-      latest_ip = ip_lease_alives.filter(:alloc_type =>NetworkVifIpLease::TYPE_AUTO).order(:updated_at.desc).first
+      latest_ip = ip_lease_alives.filter(:alloc_type =>NetworkVifIpLease::TYPE_AUTO).order(:id.desc).first
       ipaddr = latest_ip.nil? ? nil : latest_ip.ipv4_i
       leaseaddr = case network[:ip_assignment]
                   when "asc"

--- a/dcmgr/spec/dcmgr/scheduler/ip_address/incremental_examples/dont_reassign_released_addresses.rb
+++ b/dcmgr/spec/dcmgr/scheduler/ip_address/incremental_examples/dont_reassign_released_addresses.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-shared_examples 'reassign released addresses' do
+shared_examples 'dont reassign released addresses' do
   context "when previously assigned addresses have been released" do
     let(:network) do
       Fabricate(:network, ipv4_network: "192.168.0.0").tap do |n|
@@ -14,8 +14,8 @@ shared_examples 'reassign released addresses' do
       network_vif_from_ip_lease("192.168.0.3").destroy
     end
 
-    it "reassigns the lowest available address" do
-      expect(subject).to eq "192.168.0.3"
+    it "assigns the next IP, ignoring the previously released one" do
+      expect(subject).to eq "192.168.0.6"
     end
   end
 end

--- a/dcmgr/spec/dcmgr/scheduler/ip_address/incremental_spec.rb
+++ b/dcmgr/spec/dcmgr/scheduler/ip_address/incremental_spec.rb
@@ -29,7 +29,7 @@ describe Dcmgr::Scheduler::IPAddress::Incremental do
       include_examples 'one range full, one empty'
       include_examples 'gateway in dhcp range'
       include_examples 'wraparound dhcp range'
-      include_examples 'reassign released addresses'
+      include_examples 'dont reassign released addresses'
       include_examples 'dhcp range changes'
     end
   end


### PR DESCRIPTION
Fixes https://github.com/axsh/wakame-vdc/issues/475.

The problem was that the scheduler finds the last used IP by sorting on timestamp. The timestamp only goes down to seconds so it's common for a bunch of IP addresses to be created in the same second. I changed the query to use the primary key instead.