### PR TITLE
Fix vdc manage host modify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Wakame-vdc will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+`Fixed` A bug where it was possible to set an invalid hypervisor through *vdc-manage host modify*.
+
 ## [16.1] - 2015-10-2
 
 `Added` More bash completion for mussel commands. Specifically alarm, *ip_pool*, *ip_handle*, *dc_network*, *host_node*, *volume*, *network_vif* and *instance_show_password*.

--- a/dcmgr/lib/dcmgr/cli/host.rb
+++ b/dcmgr/lib/dcmgr/cli/host.rb
@@ -62,10 +62,10 @@ class Host < Base
   method_option :node_id, :type => :string, :size => 255, :desc => "The node ID for the host node"
   common_options
   def modify(uuid)
-    if options.has_key?(:arch) && !SUPPORTED_ARCH.member?(options[:arch])
+    if options[:arch] && !SUPPORTED_ARCH.member?(options[:arch])
       UnsupportedArchError.raise(options[:arch])
     end
-    if options.has_key?(:hypervisor) && !SUPPORTED_HYPERVISOR.member?(options[:hypervisor])
+    if options[:hypervisor] && !SUPPORTED_HYPERVISOR.member?(options[:hypervisor])
       UnsupportedHypervisorError.raise(options[:hypervisor])
     end
 

--- a/dcmgr/lib/dcmgr/models/host_node.rb
+++ b/dcmgr/lib/dcmgr/models/host_node.rb
@@ -52,6 +52,10 @@ module Dcmgr::Models
         errors.add(:arch, "unknown architecture type: #{self.arch}")
       end
 
+      unless SUPPORTED_HYPERVISOR.member?(self.hypervisor)
+        errors.add(:hypervisor, "unknown hypervisor: #{self.hypervisor}")
+      end
+
       if self.offering_cpu_cores < 0
         errors.add(:offering_cpu_cores, "it can not be less than zero")
       end


### PR DESCRIPTION
Fixes https://github.com/axsh/wakame-vdc/issues/757

Whatever we're using (activesupport?) is smart enough to translate symbols to strings when accessing a hash but doesn't do the same for the `has_key?` method. We also weren't validating the hypervisor in the model class.
