### PR TITLE
Fix webapi accountless crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Wakame-vdc will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+`Fixed` A bug where the WebAPI would crash when no account id was set in a request. It now fails gracefully with a 400 error instead.
+
 ## [16.1] - 2015-10-2
 
 `Added` More bash completion for mussel commands. Specifically alarm, *ip_pool*, *ip_handle*, *dc_network*, *host_node*, *volume*, *network_vif* and *instance_show_password*.

--- a/dcmgr/lib/dcmgr/endpoints/12.03/core_api.rb
+++ b/dcmgr/lib/dcmgr/endpoints/12.03/core_api.rb
@@ -37,8 +37,9 @@ module Dcmgr::Endpoints::V1203
 
     before do
       requester_account_id = request.env[HTTP_X_VDC_ACCOUNT_UUID]
+
       if requester_account_id.nil?
-        @account = nil
+        raise E::AccountIdNotSet, 'No account id was set in the HTTP headers.'
       else
         begin
           # find or create account entry.

--- a/dcmgr/lib/dcmgr/endpoints/errors.rb
+++ b/dcmgr/lib/dcmgr/endpoints/errors.rb
@@ -178,5 +178,6 @@ module Dcmgr
     define_error(:UnknownEvaluationPeriods, 400, '199')
     define_error(:UnknownNotificationPeriods, 400, '200')
     define_error(:PasswordNotInDatabase, 410, '201')
+    define_error(:AccountIdNotSet, 400, '202')
   end
 end


### PR DESCRIPTION
When not providing an account id in a request to the webapi, it would set `@account` to nil and just let things crash further down the stack.

Fixed it so it raises a proper error immediately.
