### PR TITLE
Fix keypair api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Wakame-vdc will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+`Fixed` A crash that occurred when performing a POST request to the ssh_key_pairs endpoint without including the "public_key" field in the parameters.
+
 ## [16.1] - 2015-10-2
 
 `Added` More bash completion for mussel commands. Specifically alarm, *ip_pool*, *ip_handle*, *dc_network*, *host_node*, *volume*, *network_vif* and *instance_show_password*.

--- a/dcmgr/lib/dcmgr/endpoints/12.03/ssh_key_pairs.rb
+++ b/dcmgr/lib/dcmgr/endpoints/12.03/ssh_key_pairs.rb
@@ -48,7 +48,7 @@ Dcmgr::Endpoints::V1203::CoreAPI.namespace '/ssh_key_pairs' do
     private_key = nil
     ssh = M::SshKeyPair.entry_new(@account) do |s|
 
-      unless params[:public_key].empty?
+      if params[:public_key] && !params[:public_key].empty?
         unless SSHKey.valid_ssh_public_key?(params[:public_key])
           raise InvalidSshPublicKey, params[:public_key]
         end

--- a/dcmgr/spec/dcmgr/endpoints/12.03/ssh_key_pairs_spec.rb
+++ b/dcmgr/spec/dcmgr/endpoints/12.03/ssh_key_pairs_spec.rb
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+require_relative 'helper'
+
+describe "ssh_key_pairs" do
+  describe "POST" do
+    let(:account) { Fabricate(:account) }
+
+    before(:each) do
+      stub_dcmgr_syncronized_message_ready
+
+      post("ssh_key_pairs",
+           params,
+           Dcmgr::Endpoints::HTTP_X_VDC_ACCOUNT_UUID => account.canonical_uuid)
+    end
+
+    context "with no parameters" do
+      let(:params) { Hash.new }
+
+      it "doesn't crash" do
+        #expect(last_response.errors).to be_empty
+        if !last_response.errors.empty?
+          raise "The API call crashed.\n#{last_response.errors}"
+        end
+      end
+    end
+  end
+end

--- a/dcmgr/spec/dcmgr/endpoints/12.03/ssh_key_pairs_spec.rb
+++ b/dcmgr/spec/dcmgr/endpoints/12.03/ssh_key_pairs_spec.rb
@@ -17,7 +17,6 @@ describe "ssh_key_pairs" do
       let(:params) { Hash.new }
 
       it "doesn't crash" do
-        #expect(last_response.errors).to be_empty
         if !last_response.errors.empty?
           raise "The API call crashed.\n#{last_response.errors}"
         end


### PR DESCRIPTION
The keypair api endpoint crashed when doing a post request with no parameters. Now it does not. :p 
