### PR TITLE
Store vif as List to reference this attribute

### DIFF
--- a/client/terraform-provider-wakamevdc/wakamevdc/resource_wakamevdc_instance.go
+++ b/client/terraform-provider-wakamevdc/wakamevdc/resource_wakamevdc_instance.go
@@ -76,7 +76,7 @@ func resourceWakamevdcInstance() *schema.Resource {
 			},
 
 			"vif": &schema.Schema{
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -89,6 +89,7 @@ func resourceWakamevdcInstance() *schema.Resource {
 						"ip_address": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 							ForceNew: true,
 						},
 
@@ -113,7 +114,7 @@ func resourceWakamevdcInstanceCreate(d *schema.ResourceData, m interface{}) erro
 	if v := d.Get("vif"); v != nil {
 		vifs = make(map[string]wakamevdc.InstanceCreateVIFParams)
 
-		for i, vifMapInterface := range v.(*schema.Set).List() {
+		for i, vifMapInterface := range v.([]interface{}) {
 			vifMap := vifMapInterface.(map[string]interface{})
 
 			vifStruct := wakamevdc.InstanceCreateVIFParams{
@@ -185,6 +186,15 @@ func resourceWakamevdcInstanceRead(d *schema.ResourceData, m interface{}) error 
 	d.Set("display_name", inst.DisplayName)
 	d.Set("state", inst.State)
 	d.Set("status", inst.Status)
+
+	vifs := make([]map[string]interface{}, len(inst.VIFs))
+	for i, vif := range inst.VIFs {
+		vifs[i] = make(map[string]interface{})
+		vifs[i]["network_id"] = vif.NetworkID
+		vifs[i]["ip_address"] = vif.IPv4.Address
+		vifs[i]["security_groups"] = vif.SecurityGroupIDs
+	}
+	d.Set("vif", vifs)
 
 	return err
 }


### PR DESCRIPTION
1つのインスタンスに対しvifを複数定義した場合、それぞれがeth0, eth1, eth2...として扱われます。
順番に意味があるため、vifに関してはTypeSetよりTypeListの方が適切かと思われます。

また、DHCPによってIPが振られた場合、`${wakamevdc_instance.test.vif.0.ip_address}`として参照ができなかった為、vifを構築して格納する処理を追加しました。
