### PR TITLE
Fix lxc wakame init

### DIFF
--- a/vmapp/load_balancer/image.ini
+++ b/vmapp/load_balancer/image.ini
@@ -1,13 +1,13 @@
 [vmbuilder]
 
-name = lb-centos6.6-stud
+name = lb-centos6.7-stud
 
 rootsize      = 2048
 swapsize      = 0
 
 hypervisor    = kvm, lxc, openvz
 distro-name   = centos
-distro-ver    = 6.6
+distro-ver    = 6.7
 arch          = x86_64;, i686
 sshd-passauth = no
 fstab-type    = label

--- a/wakame-init/rhel/6/wakame-init
+++ b/wakame-init/rhel/6/wakame-init
@@ -168,7 +168,6 @@ function set_network_configuration() {
     cat <<_IFCFG > "/etc/sysconfig/network-scripts/ifcfg-${nic}"
 DEVICE="${nic}"
 BOOTPROTO="static"
-HWADDR="${mac}"
 IPV6INIT="${IPV6INIT:-yes}"
 IPV6_AUTOCONF="${IPV6_AUTOCONF:-yes}"
 NM_CONTROLLED="yes"


### PR DESCRIPTION
Workaround for the wakame-init script to make Centos 6 instances work on LXC
