### PR TITLE
Fix openvnet resources update

### DIFF
--- a/dcmgr/lib/dcmgr/endpoints/12.03/security_groups.rb
+++ b/dcmgr/lib/dcmgr/endpoints/12.03/security_groups.rb
@@ -51,15 +51,6 @@ Dcmgr::Endpoints::V1203::CoreAPI.namespace '/security_groups' do
     # params rule, string
     # params display_name, string
 
-    # Port range not supported in openvnet, raise
-    # error if start/end port differ
-    if Dcmgr::Configurations.dcmgr.features.openvnet
-      params[:rule].split(/\r?\n/).each { |rule|
-        r = split_rule(rule)
-        raise E::InvalidSecurityGroupRule, rule if r[:port_start] != r[:port_end]
-      }
-    end
-
     begin
       savedata = {
         :account_id=>@account.canonical_uuid,

--- a/dcmgr/lib/dcmgr/models/security_group.rb
+++ b/dcmgr/lib/dcmgr/models/security_group.rb
@@ -115,7 +115,10 @@ module Dcmgr::Models
       if Dcmgr::Configurations.dcmgr.features.openvnet
         prule = self.class.parse_rule(rule)
 
-        if prule[:ip_fport] != prule[:ip_tport]
+        if prule &&
+          [:tcp, :udp].member?(prule[:protocol]) &&
+          prule[:ip_fport] != prule[:ip_tport]
+
           raise InvalidSecurityGroupRuleSyntax, "OpenVNet does not support port ranges: #{rule}"
         end
       end

--- a/dcmgr/lib/dcmgr/models/security_group.rb
+++ b/dcmgr/lib/dcmgr/models/security_group.rb
@@ -107,6 +107,20 @@ module Dcmgr::Models
       super
     end
 
+    def validate
+      super
+
+      # Port range not supported in openvnet, raise
+      # error if start/end port differ
+      if Dcmgr::Configurations.dcmgr.features.openvnet
+        prule = self.class.parse_rule(rule)
+
+        if prule[:ip_fport] != prule[:ip_tport]
+          raise InvalidSecurityGroupRuleSyntax, "OpenVNet does not support port ranges: #{rule}"
+        end
+      end
+    end
+
     def after_save
       handle_refs(:create)
       super

--- a/dcmgr/lib/sinatra/vnet_webapi.rb
+++ b/dcmgr/lib/sinatra/vnet_webapi.rb
@@ -31,7 +31,7 @@ module Sinatra
           if request.path_info == "/networks"
             VNetAPIClient::Network.create(
               uuid: r[:uuid],
-              display_name: r[:uuid],
+              display_name: params[:display_name] || r[:uuid],
               ipv4_network: params[:network],
               ipv4_prefix: params[:prefix],
               network_mode: 'virtual'
@@ -41,7 +41,7 @@ module Sinatra
           if request.path_info == "/security_groups"
             VNetAPIClient::SecurityGroup.create(
               uuid: r[:uuid],
-              display_name: r[:uuid],
+              display_name: params[:display_name] || r[:uuid],
               description: params[:description],
               rules: openvnet_rules(params[:rule]).join("\n")
             )
@@ -52,7 +52,7 @@ module Sinatra
           if path == "security_groups"
             vnet_params = {}
 
-            # Not updating display name since it's always set to uuid on creation
+            vnet_params[:display_name] = params[:display_name] if params[:display_name]
             vnet_params[:description] = params[:description] if params[:description]
             vnet_params[:rules] = openvnet_rules(params[:rule]).join("\n") if params[:rule]
 

--- a/dcmgr/lib/sinatra/vnet_webapi.rb
+++ b/dcmgr/lib/sinatra/vnet_webapi.rb
@@ -58,6 +58,12 @@ module Sinatra
 
             VNetAPIClient::SecurityGroup.update(uuid, vnet_params)
           end
+
+          if path == "networks"
+            vnet_params = {}
+            vnet_params[:display_name] = params[:display_name] if params[:display_name]
+            VNetAPIClient::Network.update(uuid, vnet_params)
+          end
         else
           VNetAPIClient::Network.delete(r.first) if request.path_info.include?("/networks")
           VNetAPIClient::SecurityGroup.delete(r.first) if request.path_info.include?("/security_groups")


### PR DESCRIPTION
Implementes update calls for OpenVNet networks and security groups. Currently networks only allow updating display name since that's the only thing that can be updated in Wakame-vdc's webapi.

Fixes https://github.com/axsh/wakame-vdc/issues/776 in the process.
