### PR TITLE
Fix dhcp range cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 `Fixed` A bug that would some times occur when starting LXC instances, causing `/dev/pty` to become mounted read only.
 
+`Fixed` A bug where dhcp ranges would remain in the database after their associated network was deleted.
+
 ## [16.1] - 2015-10-2
 
 `Added` More bash completion for mussel commands. Specifically alarm, *ip_pool*, *ip_handle*, *dc_network*, *host_node*, *volume*, *network_vif* and *instance_show_password*.

--- a/dcmgr/lib/dcmgr/models/network.rb
+++ b/dcmgr/lib/dcmgr/models/network.rb
@@ -281,6 +281,8 @@ module Dcmgr::Models
         n.save
       }
 
+      self.dhcp_range.each { |i| i.destroy }
+
       #Delete all reserved ipleases in this network
       self.network_vif_ip_lease_dataset.filter(:alloc_type => NetworkVifIpLease::TYPE_RESERVED).each { |i|
         i.destroy


### PR DESCRIPTION
While working on terraform, I noticed that networks I created had different dhcp ranges than I expected. The problem was that dhcp ranges didn't get deleted along with the networks. Old dhcp ranges belonging to networks that didn't exist remained in the database, creating the following problem:

1) Network _nw-xxx_ is created and gets `id` (primary key) 1 in the database.

2) A DHCP range _rangex_ is created and assigned to _nw-xxx_, this it's `network_id` in the database is 1.

3) Network _nw-xxx_ is deleted. DHCP range _rangex_ stays in the database.

4) Network _nw-yyy_ is created and reuses `id` 1.

5) **Bug:** Network _nw-yyy_ now owns _rangex_ which stayed in the database with `network_id` 1.
